### PR TITLE
Add workflow to automatically generate CLI builds when a new release is created

### DIFF
--- a/.github/_workflows/release.yml
+++ b/.github/_workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
-on: release
+on:
+  never
 
 jobs:
   build-cli:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,20 @@ jobs:
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.target }}-cargo-${{ runner.os }}-
+            ${{ matrix.target }}-cargo-
+
       - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   publish-to-crates-io:
+    if: ${{ github.ref_name }} == 'master'
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name }} == "master"
     steps:
       - uses: actions/checkout@v3
       - run: cargo publish --verbose --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build-cli:
@@ -28,8 +29,22 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
-      - uses: Shopify/upload-to-release@v1.0.1
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: wasm2spirv-${{ matrix.target }}${{ matrix.ext }}
-          path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: true
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: wasm2spirv-${{ matrix.target }}${{ matrix.ext }}
+          asset_path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,21 +30,33 @@ jobs:
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
 
+      - name: Compress executable
+        id: zipped
+        uses: thedoctor0/zip-release@0.7.1
+        with:
+          path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wasm2spirv-${{ matrix.target }}
+          path: release.zip
+
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: true
-
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: wasm2spirv-${{ matrix.target }}${{ matrix.ext }}
-          asset_path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
+          name: Release ${{ github.ref }}
+          generate_release_notes: true
+          files: ${{ steps.download.outputs.download-path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,11 @@ jobs:
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
 
-      - name: Compress executable
-        uses: thedoctor0/zip-release@0.7.1
-        with:
-          path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
-
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: wasm2spirv-${{ matrix.target }}
-          path: release.zip
+          path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
 
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,5 @@ jobs:
         with:
           file: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
           asset_name: ${{ matrix.target }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,6 @@ on:
     types: [published]
 
 jobs:
-  publish-to-crates-io:
-    if: ${{ github.ref_name }} == 'master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: cargo publish --verbose --token ${{ secrets.CRATES_IO_TOKEN }}
-
   build-cli:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-cli:
+    permissions:
+      contents: write
     strategy:
       matrix:
         target:
@@ -25,8 +27,10 @@ jobs:
             os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v3
+
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -39,9 +43,19 @@ jobs:
             ${{ matrix.target }}-cargo-${{ runner.os }}-
             ${{ matrix.target }}-cargo-
 
-      - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
+
+      - name: Save cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Upload to release
         uses: svenstaro/upload-release-action@2.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
 
       - name: Compress executable
-        id: zipped
         uses: thedoctor0/zip-release@0.7.1
         with:
           path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
@@ -44,12 +43,20 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
+    needs: build-cli
     steps:
       - name: Download artifacts
-        id: download
         uses: actions/download-artifact@v3
         with:
           path: artifacts
+
+      - name: List all downloaded artifacts
+        id: files
+        uses: mirko-felice/list-files-action@v3.0.5
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          path: artifact
 
       - name: Create Release
         id: create_release
@@ -59,4 +66,5 @@ jobs:
           prerelease: true
           name: Release ${{ github.ref }}
           generate_release_notes: true
-          files: ${{ steps.download.outputs.download-path }}
+          files: |
+                  ${{ steps.files.outputs.paths }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - '*'
 
 jobs:
   build-cli:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-to-crates-io:
     runs-on: ubuntu-latest
+    if: ${{ github.ref_name }} == "master"
     steps:
       - uses: actions/checkout@v3
       - run: cargo publish --verbose --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - '*'
+on: release
 
 jobs:
   build-cli:
@@ -17,51 +14,26 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            mime: application/x-pie-executable
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: .exe
+            mime: application/vnd.microsoft.portable-executable
           - target: aarch64-apple-darwin
             os: macos-latest
+            mime: application/x-pie-executable
           - target: x86_64-apple-darwin
             os: macos-latest
+            mime: application/x-pie-executable
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
+      - name: Upload to release
+        uses: JasonEtco/upload-to-release@master
         with:
-          name: wasm2spirv-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
-
-  create-release:
-    runs-on: ubuntu-latest
-    needs: build-cli
-    env:
-      ARTIFACTS_PATH: artifacts
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: ${{ env.ARTIFACTS_PATH }}
-
-      - name: List all downloaded artifacts
-        id: files
-        uses: mirko-felice/list-files-action@v3.0.5
-        with:
-          repo: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          path: ${{ env.ARTIFACTS_PATH }}
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          prerelease: true
-          name: Release ${{ github.ref }}
-          generate_release_notes: true
-          files: |
-                  ${{ steps.files.outputs.paths }}
+          args: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }} ${{ matrix.mime }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 on:
-  never
+  release:
+    types: [published]
 
 jobs:
   build-cli:
@@ -15,17 +16,13 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            mime: application/x-pie-executable
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: .exe
-            mime: application/vnd.microsoft.portable-executable
           - target: aarch64-apple-darwin
             os: macos-latest
-            mime: application/x-pie-executable
           - target: x86_64-apple-darwin
             os: macos-latest
-            mime: application/x-pie-executable
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -33,8 +30,7 @@ jobs:
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
 
       - name: Upload to release
-        uses: JasonEtco/upload-to-release@master
+        uses: svenstaro/upload-release-action@2.6.1
         with:
-          args: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }} ${{ matrix.mime }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
+          asset_name: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,13 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: build-cli
+    env:
+      ARTIFACTS_PATH: artifacts
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: artifacts
+          path: ${{ env.ARTIFACTS_PATH }}
 
       - name: List all downloaded artifacts
         id: files
@@ -56,7 +58,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           ref: ${{ github.ref }}
-          path: artifact
+          path: ${{ env.ARTIFACTS_PATH }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,6 @@ jobs:
         uses: svenstaro/upload-release-action@2.6.1
         with:
           file: target/${{ matrix.target }}/release/wasm2spirv${{ matrix.ext }}
-          asset_name: ${{ matrix.target }}
+          asset_name: wasm2spirv-${{ matrix.target }}${{ matrix.ext }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - run: rustup target add ${{ matrix.target }}
       - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
       - uses: Shopify/upload-to-release@v1.0.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,12 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,15 +306,6 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -866,12 +851,9 @@ dependencies = [
 name = "wasm2spirv"
 version = "0.1.1"
 dependencies = [
- "bitflags 2.3.3",
  "clap",
  "color-eyre",
  "docfg",
- "itertools",
- "num-traits",
  "num_enum",
  "once_cell",
  "rspirv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,9 @@ required-features = [
 ]
 
 [dependencies]
-bitflags = "2.3.3"
 clap = { version = "4.3.16", optional = true, features = ["derive", "env"] }
 color-eyre = { version = "0.6.2", optional = true }
 docfg = "0.1.0"
-itertools = "0.11.0"
-num-traits = "0.2.15"
 num_enum = "0.6.1"
 once_cell = "1.18.0"
 rspirv = "0.11.0"


### PR DESCRIPTION
This new workflow will generate CLI builds for the following targets and upload them as assets to the release that triggered the workflow.

## Currently targeted platforms
* 64-bit x86 Windows (**x86_64-pc-windows-msvc**)
* 64-bit x86 Linux (**x86_64-unknown-linux-gnu**)
* Apple Silicon macOS (**aarch64-apple-darwin**)
* 64-bit x86 macOS (**x86_64-apple-darwin**)