### PR TITLE
Improved control flow, dynamic detection of structured ifs and loops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
             - dot
             - saxpy
             - square
+            - fragment
           target:
             - x86_64-pc-windows-msvc
             - x86_64-unknown-linux-gnu

--- a/examples/fragment/fragment.json
+++ b/examples/fragment/fragment.json
@@ -10,24 +10,31 @@
     "functions": {
         "0": {
             "execution_model": "Fragment",
+            "execution_mode": "origin_upper_left",
             "params": {
                 "0": {
                     "type": "f32",
-                    "kind": "input"
+                    "kind": {
+                        "input": 0
+                    }
                 },
                 "1": {
                     "type": "i32",
-                    "kind": "input"
+                    "kind": {
+                        "input": 1
+                    }
                 },
                 "2": {
                     "type": "f32",
-                    "kind": "input"
+                    "kind": {
+                        "input": 3
+                    }
                 },
                 "3": {
-                    "type": {
-                        "Structured": "f32"
+                    "type": "f32",
+                    "kind": {
+                        "output": 4
                     },
-                    "kind": "output",
                     "is_extern_pointer": true
                 }
             }

--- a/examples/fragment/fragment.json
+++ b/examples/fragment/fragment.json
@@ -27,13 +27,13 @@
                 "2": {
                     "type": "f32",
                     "kind": {
-                        "input": 3
+                        "input": 2
                     }
                 },
                 "3": {
                     "type": "f32",
                     "kind": {
-                        "output": 4
+                        "output": 3
                     },
                     "is_extern_pointer": true
                 }

--- a/examples/fragment/fragment.json
+++ b/examples/fragment/fragment.json
@@ -1,0 +1,36 @@
+{
+    "platform": {
+        "vulkan": "1.1"
+    },
+    "version": "1.3",
+    "addressing_model": "logical",
+    "memory_model": "GLSL450",
+    "capabilities": { "dynamic": [] },
+    "extensions": [],
+    "functions": {
+        "0": {
+            "execution_model": "Fragment",
+            "params": {
+                "0": {
+                    "type": "f32",
+                    "kind": "input"
+                },
+                "1": {
+                    "type": "i32",
+                    "kind": "input"
+                },
+                "2": {
+                    "type": "f32",
+                    "kind": "input"
+                },
+                "3": {
+                    "type": {
+                        "Structured": "f32"
+                    },
+                    "kind": "output",
+                    "is_extern_pointer": true
+                }
+            }
+        }
+    }
+}

--- a/examples/fragment/fragment.wat
+++ b/examples/fragment/fragment.wat
@@ -1,0 +1,46 @@
+(module
+  (type (;0;) (func (param f32 i32 f32 i32)))
+  (func (;0;) (type 0) (param f32 i32 f32 i32)
+    block  ;; label = @1
+      block  ;; label = @2
+        local.get 1
+        i32.eqz
+        br_if 0 (;@2;)
+        local.get 0
+        local.get 2
+        f32.add
+        local.set 0
+        br 1 (;@1;)
+      end
+      local.get 0
+      local.get 0
+      f32.add
+      local.get 2
+      f32.div
+      local.set 0
+    end
+    i32.const 4
+    local.set 1
+    block  ;; label = @1
+      loop  ;; label = @2
+        local.get 1
+        i32.eqz
+        br_if 1 (;@1;)
+        local.get 1
+        i32.const -1
+        i32.add
+        local.set 1
+        local.get 0
+        local.get 2
+        f32.mul
+        local.set 0
+        br 0 (;@2;)
+      end
+    end
+    local.get 3
+    local.get 0
+    f32.store)
+  (memory (;0;) 16)
+  (global (;0;) (mut i32) (i32.const 1048576))
+  (export "memory" (memory 0))
+  (export "main" (func 0)))

--- a/examples/fragment/fragment.zig
+++ b/examples/fragment/fragment.zig
@@ -1,11 +1,14 @@
 export fn main(og_color: f32, cond: bool, scale: f32, color: *f32) void {
+    var out_color: f32 = undefined;
     if (cond) {
-        color.* = og_color + scale;
+        out_color = og_color + scale;
     } else {
-        color.* = (2 * og_color) / scale;
+        out_color = (2 * og_color) / scale;
     }
 
     for (0..4) |_| {
-        color.* *= scale;
+        out_color *= scale;
     }
+
+    color.* = out_color;
 }

--- a/examples/fragment/fragment.zig
+++ b/examples/fragment/fragment.zig
@@ -1,0 +1,11 @@
+export fn main(og_color: f32, cond: bool, scale: f32, color: *f32) void {
+    if (cond) {
+        color.* = og_color + scale;
+    } else {
+        color.* = (2 * og_color) / scale;
+    }
+
+    for (0..4) |_| {
+        color.* *= scale;
+    }
+}

--- a/src/decorator.rs
+++ b/src/decorator.rs
@@ -8,6 +8,8 @@ pub enum VariableDecorator {
     BuiltIn(BuiltIn),
     DesctiptorSet(u32),
     Binding(u32),
+    Location(u32),
+    Flat,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +39,10 @@ impl VariableDecorator {
             VariableDecorator::Binding(x) => {
                 builder.decorate(target, Decoration::Binding, [Operand::LiteralInt32(*x)])
             }
+            VariableDecorator::Location(x) => {
+                builder.decorate(target, Decoration::Location, [Operand::LiteralInt32(*x)])
+            }
+            VariableDecorator::Flat => builder.decorate(target, Decoration::Flat, None),
         }
     }
 }

--- a/src/fg/block.rs
+++ b/src/fg/block.rs
@@ -227,7 +227,7 @@ impl<'a> BlockReader<'a> {
                 Operator::End => match inner_branches.checked_sub(1) {
                     Some(x) => inner_branches = x,
                     None => {
-                        let mut cache = self.cache.split_off(i);
+                        let mut cache = self.cache.split_off(i + 1);
                         core::mem::swap(&mut cache, &mut self.cache);
                         return Ok(BlockReader {
                             reader: None,

--- a/src/fg/mod.rs
+++ b/src/fg/mod.rs
@@ -11,17 +11,16 @@ pub mod import;
 pub mod module;
 pub mod values;
 
-#[derive(Debug, Clone)]
-pub enum ControlFlow {
-    LoopMerge {
-        merge_block: Rc<Label>,
-        continue_target: Rc<Label>,
-    },
-    SelectionMerge(Rc<Label>),
+#[derive(Debug, PartialEq)]
+pub enum MergeBlock {
+    This,
+    Label(Rc<Label>),
 }
 
-#[derive(Debug, Default)]
-pub struct Label(pub(crate) Cell<Option<rspirv::spirv::Word>>);
+#[derive(Debug, PartialEq, Default)]
+pub struct Label {
+    pub(crate) translation: Cell<Option<rspirv::spirv::Word>>,
+}
 
 #[derive(Debug, Clone)]
 pub enum End {
@@ -35,13 +34,11 @@ pub enum Operation {
     Label(Rc<Label>),
     Branch {
         label: Rc<Label>,
-        control_flow: Option<ControlFlow>,
     },
     BranchConditional {
         condition: Rc<Bool>,
         true_label: Rc<Label>,
         false_label: Rc<Label>,
-        control_flow: Option<ControlFlow>,
     },
     Store {
         target: Storeable,
@@ -60,10 +57,42 @@ pub enum Operation {
     },
     Nop,
     Unreachable,
-    End {
-        kind: End,
+    Return {
         value: Option<Value>,
     },
+}
+
+impl Operation {
+    pub fn is_function_terminating(&self) -> bool {
+        return matches!(self, Operation::Return { .. } | Operation::Unreachable);
+    }
+
+    pub fn is_branch_instruction(&self) -> bool {
+        return matches!(
+            self,
+            Operation::Branch { .. } | Operation::BranchConditional { .. }
+        );
+    }
+
+    pub fn is_block_terminating(&self) -> bool {
+        self.is_function_terminating() || self.is_branch_instruction()
+    }
+}
+
+impl PartialEq<Rc<Label>> for Operation {
+    fn eq(&self, other: &Rc<Label>) -> bool {
+        match self {
+            Operation::Label(x) => Rc::ptr_eq(x, other),
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<Operation> for Rc<Label> {
+    #[inline]
+    fn eq(&self, other: &Operation) -> bool {
+        other == self
+    }
 }
 
 impl<T: Into<Value>> From<T> for Operation {

--- a/src/fg/mod.rs
+++ b/src/fg/mod.rs
@@ -63,6 +63,32 @@ pub enum Operation {
 }
 
 impl Operation {
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Operation::Value(x), Operation::Value(y)) => x.ptr_eq(y),
+            (Operation::Label(x), Operation::Label(y))
+            | (Operation::Branch { label: x }, Operation::Branch { label: y }) => Rc::ptr_eq(x, y),
+            (
+                Operation::BranchConditional {
+                    condition,
+                    true_label,
+                    false_label,
+                },
+                Operation::BranchConditional {
+                    condition: other_condition,
+                    true_label: other_true_label,
+                    false_label: other_false_label,
+                },
+            ) => {
+                Rc::ptr_eq(condition, other_condition)
+                    && Rc::ptr_eq(true_label, other_true_label)
+                    && Rc::ptr_eq(false_label, other_false_label)
+            }
+            // TODO are ops without values equal?
+            _ => false,
+        }
+    }
+
     pub fn is_function_terminating(&self) -> bool {
         return matches!(self, Operation::Return { .. } | Operation::Unreachable);
     }

--- a/src/fg/values/mod.rs
+++ b/src/fg/values/mod.rs
@@ -29,6 +29,17 @@ pub enum Value {
 }
 
 impl Value {
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::Integer(x), Value::Integer(y)) => Rc::ptr_eq(x, y),
+            (Value::Float(x), Value::Float(y)) => Rc::ptr_eq(x, y),
+            (Value::Pointer(x), Value::Pointer(y)) => Rc::ptr_eq(x, y),
+            (Value::Vector(x), Value::Vector(y)) => Rc::ptr_eq(x, y),
+            (Value::Bool(x), Value::Bool(y)) => Rc::ptr_eq(x, y),
+            _ => false,
+        }
+    }
+
     pub fn ty(&self, module: &ModuleBuilder) -> Result<Type> {
         return Ok(match self {
             Value::Bool(_) => Type::Scalar(ScalarType::Bool),

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -939,12 +939,19 @@ impl Translation for &Rc<Pointer> {
                             _ => {}
                         }
 
-                        let element = byte_element
-                            .clone()
-                            .u_div(element_size, module)?
-                            .translate(module, function, builder)?;
+                        match byte_element.get_constant_value()? {
+                            Some(IntConstantSource::Short(0) | IntConstantSource::Long(0)) => {
+                                Ok(base)
+                            }
+                            _ => {
+                                let element = byte_element
+                                    .clone()
+                                    .u_div(element_size, module)?
+                                    .translate(module, function, builder)?;
 
-                        builder.ptr_access_chain(pointer_type, None, base, element, None)
+                                builder.ptr_access_chain(pointer_type, None, base, element, None)
+                            }
+                        }
                     }
                 }
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -92,7 +92,7 @@ fn test() -> color_eyre::Result<()> {
     //let wat = include_str!("saxpy.wat");
     //let wasm = wat::parse_str(include_str!("../examples/saxpy.wat"))?;
 
-    let wasm = wat::parse_bytes(include_bytes!("../examples/saxpy.wat"))?;
+    let wasm = wat::parse_bytes(include_bytes!("../examples/saxpy/saxpy.wat"))?;
     let module = ModuleBuilder::new(config, &wasm)?;
     let spirv = module.translate().unwrap();
 


### PR DESCRIPTION
Previously, conditional branches were always marked as loop merges, but this is obviously wrong, since it doesn't account for ifs (selection merges). This has been improved, though more tests have to be done to ensure this is 100% correct