### PR TITLE
Added WebAssembly CLI build on release & support naga compilers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,25 @@ jobs:
           - x86_64-unknown-linux-gnu
           - aarch64-apple-darwin
           - x86_64-apple-darwin
+          - wasm32-wasi
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            features: khronos-all naga-wgsl
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            features: khronos-all naga-wgsl
             ext: .exe
           - target: aarch64-apple-darwin
             os: macos-latest
+            features: khronos-all naga-wgsl
           - target: x86_64-apple-darwin
             os: macos-latest
+            features: khronos-all naga-wgsl
+          - target: wasm32-wasi
+            os: ubuntu-latest
+            features: naga-all
+            ext: .wasm
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -46,7 +55,7 @@ jobs:
             ${{ matrix.target }}-cargo-
 
       - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --verbose --release --bin wasm2spirv --all-features --target ${{ matrix.target }}
+      - run: cargo build --verbose --release --bin wasm2spirv --features="cli ${{ matrix.features }}" --target ${{ matrix.target }}
 
       - name: Save cache
         uses: actions/cache/save@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ matrix.target }}-cargo-${{ runner.os }}-release
             ${{ matrix.target }}-cargo-${{ runner.os }}-
             ${{ matrix.target }}-cargo-
 
@@ -66,7 +67,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Upload to release
         uses: svenstaro/upload-release-action@2.6.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,43 +3,43 @@ name: Tests
 on: push
 
 jobs:
-    test-examples:
-      strategy:
-        matrix:
-          example:
-            - dot
-            - saxpy
-            - square
-            - fragment
-          target:
-            - x86_64-pc-windows-msvc
-            - x86_64-unknown-linux-gnu
-            - x86_64-apple-darwin
-          include:
-            - target: x86_64-unknown-linux-gnu
-              os: ubuntu-latest
-            - target: x86_64-pc-windows-msvc
-              os: windows-latest
-            - target: x86_64-apple-darwin
-              os: macos-latest
+  test-examples:
+    strategy:
+      matrix:
+        example:
+          - dot
+          - saxpy
+          - square
+          - fragment
+        target:
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
 
-      runs-on: ${{ matrix.os }}
-      steps:
-      - uses: actions/checkout@v3
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
 
-      - name: Restore cache
-        uses: actions/cache@v3
-        with:
-          path: |
-              ~/.cargo/bin/
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-              target/
-          key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-              ${{ matrix.target }}-cargo-${{ runner.os }}-
-              ${{ matrix.target }}-cargo-
+    - name: Restore cache
+      uses: actions/cache@v3
+      with:
+        path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+        key: ${{ matrix.target }}-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+            ${{ matrix.target }}-cargo-${{ runner.os }}-
+            ${{ matrix.target }}-cargo-
 
-      - run: rustup target add ${{ matrix.target }}
-      - run: cargo run --bin wasm2spirv --all-features -- examples/${{ matrix.example }}/${{ matrix.example }}.wat --from-json examples/${{ matrix.example }}/${{ matrix.example }}.json --validate
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo run --bin wasm2spirv --all-features -- examples/${{ matrix.example }}/${{ matrix.example }}.wat --from-json examples/${{ matrix.example }}/${{ matrix.example }}.json --validate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
             ${{ matrix.target }}-cargo-
 
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo run --bin wasm2spirv --all-features -- examples/${{ matrix.example }}/${{ matrix.example }}.wat --from-json examples/${{ matrix.example }}/${{ matrix.example }}.json --validate
+    - run: cargo run --bin wasm2spirv --features="cli spvt-validate" -- examples/${{ matrix.example }}/${{ matrix.example }}.wat --from-json examples/${{ matrix.example }}/${{ matrix.example }}.json --validate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,7 +425,9 @@ dependencies = [
  "indexmap 1.9.3",
  "log",
  "num-traits",
+ "petgraph",
  "rustc-hash",
+ "spirv",
  "thiserror",
 ]
 
@@ -489,6 +497,16 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap 1.9.3",
+]
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +280,12 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -289,12 +310,22 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -375,6 +406,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "naga"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
+dependencies = [
+ "bit-set",
+ "bitflags 2.3.3",
+ "indexmap 1.9.3",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -494,6 +540,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -676,7 +728,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]
@@ -854,6 +906,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "docfg",
+ "naga",
  "num_enum",
  "once_cell",
  "rspirv",
@@ -876,7 +929,7 @@ version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf9564f29de2890ee34406af52d2a92dec6ef044c8ddfc5add5db8dcfd36e6c"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "semver",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,18 @@ license = "MIT"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+# SPIR-V Cross compilers
+spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
+spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]
+spvc-msl = ["spirv_cross", "spirv_cross/msl"]
+
+# Naga compilers
+naga-glsl = ["naga", "naga/glsl-out"]
+naga-hlsl = ["naga", "naga/hlsl-out"]
+naga-msl = ["naga", "naga/msl-out"]
+naga-wgsl = ["naga", "naga/glsl-out"]
+
 [lib]
 path = "src/lib.rs"
 
@@ -38,11 +50,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.103", optional = true }
 spirv = { version = "0.2.0", features = ["serde", "serialize", "deserialize"] }
 spirv-tools = { version = "0.9.0", optional = true }
-spirv_cross = { version = "0.23.1", optional = true, features = [
-    "glsl",
-    "hlsl",
-    "msl",
-] }
+spirv_cross = { version = "0.23.1", optional = true }
 thiserror = "1.0.43"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ required-features = ["clap", "color-eyre", "serde_json"]
 clap = { version = "4.3.16", optional = true, features = ["derive", "env"] }
 color-eyre = { version = "0.6.2", optional = true }
 docfg = "0.1.0"
+naga = { version = "0.13.0", optional = true }
 num_enum = "0.6.1"
 once_cell = "1.18.0"
 rspirv = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 # Macro features
 cli = ["clap", "color-eyre", "serde_json"]
-khronos-compilers = ["spvc-glsl", "spvc-hlsl", "spvc-msl"]
-naga-compilers = ["naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
+khronos-all = ["spirv-tools", "spvc-glsl", "spvc-hlsl", "spvc-msl"]
+naga-all = ["naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
 # SPIR-V Cross compilers
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]
@@ -31,7 +31,7 @@ spvc-msl = ["spirv_cross", "spirv_cross/msl"]
 naga-glsl = ["naga", "naga/glsl-out"]
 naga-hlsl = ["naga", "naga/hlsl-out"]
 naga-msl = ["naga", "naga/msl-out"]
-naga-wgsl = ["naga", "naga/glsl-out"]
+naga-wgsl = ["naga", "naga/wgsl-out"]
 
 [lib]
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ required-features = ["clap", "color-eyre", "serde_json"]
 
 [dependencies]
 clap = { version = "4.3.16", optional = true, features = ["derive", "env"] }
-color-eyre = { version = "0.6.2", features = ["spv-in"], optional = true }
+color-eyre = { version = "0.6.2", optional = true }
 docfg = "0.1.0"
-naga = { version = "0.13.0", optional = true }
+naga = { version = "0.13.0", features = ["spv-in"], optional = true }
 num_enum = "0.6.1"
 once_cell = "1.18.0"
 rspirv = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]
 spvc-msl = ["spirv_cross", "spirv_cross/msl"]
-
 # Naga compilers
 naga-glsl = ["naga", "naga/glsl-out"]
 naga-hlsl = ["naga", "naga/hlsl-out"]
@@ -40,7 +39,7 @@ required-features = ["clap", "color-eyre", "serde_json"]
 
 [dependencies]
 clap = { version = "4.3.16", optional = true, features = ["derive", "env"] }
-color-eyre = { version = "0.6.2", optional = true }
+color-eyre = { version = "0.6.2", features = ["spv-in"], optional = true }
 docfg = "0.1.0"
 naga = { version = "0.13.0", optional = true }
 num_enum = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+# Macro features
+cli = ["clap", "color-eyre", "serde_json"]
+khronos-compilers = ["spvc-glsl", "spvc-hlsl", "spvc-msl"]
+naga-compilers = ["naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
 # SPIR-V Cross compilers
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Macro features
 cli = ["clap", "color-eyre", "serde_json"]
 khronos-all = ["spvt-validate", "spvc-glsl", "spvc-hlsl", "spvc-msl"]
-naga-all = ["naga-validate", "naga-hlsl", "naga-msl", "naga-wgsl"]
+naga-all = ["naga-validate", "naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
 # SPIR-V Cross compilers
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "wasm2spirv"
 path = "src/cli.rs"
-required-features = [
-    "clap",
-    "color-eyre",
-    "serde_json",
-    "spirv-tools",
-    "spirv_cross",
-]
+required-features = ["clap", "color-eyre", "serde_json"]
 
 [dependencies]
 clap = { version = "4.3.16", optional = true, features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,31 @@ repository = "https://github.com/Aandreba/wasm2spirv"
 license = "MIT"
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["khronos-all", "naga-wgsl"]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Macro features
 cli = ["clap", "color-eyre", "serde_json"]
-khronos-all = ["spirv-tools", "spvc-glsl", "spvc-hlsl", "spvc-msl"]
-naga-all = ["naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
+khronos-all = ["spvt-validate", "spvc-glsl", "spvc-hlsl", "spvc-msl"]
+naga-all = ["naga-validate", "naga-hlsl", "naga-msl", "naga-wgsl"]
 # SPIR-V Cross compilers
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl"]
 spvc-msl = ["spirv_cross", "spirv_cross/msl"]
+spvt-validate = ["spirv-tools"]
 # Naga compilers
 naga-glsl = ["naga", "naga/glsl-out"]
 naga-hlsl = ["naga", "naga/hlsl-out"]
 naga-msl = ["naga", "naga/msl-out"]
 naga-wgsl = ["naga", "naga/wgsl-out"]
+naga-validate = ["naga", "naga/validate"]
 
 [lib]
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ wasm2spirv allows you to compile any WebAssembly program into a SPIR-V shader
   [`spirv-tools`](https://github.com/EmbarkStudios/spirv-tools-rs)
 - Can be compiled to WebAssembly itself
   - You won't be able to use `spirv-tools` or `spirv_cross` in WebAssembly
+  - CLI will have to be compiled to WASI
 
 ## Caveats
 
@@ -39,19 +40,20 @@ wasm2spirv allows you to compile any WebAssembly program into a SPIR-V shader
 
 ## Compilation Targets
 
-| Target      | Windows         | Linux           | macOS           | WebAssembly |
-| ----------- | --------------- | --------------- | --------------- | ----------- |
-| SPIR-V      | ✅              | ✅              | ✅              | ✅          |
-| GLSL        | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ❌          |
-| HLSL        | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ❌          |
-| Metal (MSL) | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ☑️ (spirv_cross) | ❌          |
-| DXIL        | ❌              | ❌              | ❌              | ❌          |
-| OpenCL C    | ❌              | ❌              | ❌              | ❌          |
-| WGSL        | ❌              | ❌              | ❌              | ❌          |
-| Cuda        | ❌              | ❌              | ❌              | ❌          |
+| Target      | Windows                         | Linux                           | macOS                           | WebAssembly       |
+| ----------- | ------------------------------- | ------------------------------- | ------------------------------- | ----------------- |
+| SPIR-V      | ✅                              | ✅                              | ✅                              | ✅                |
+| GLSL        | ☑️ (spvc-glsl/naga-glsl)         | ☑️ (spvc-glsl/naga-glsl)         | ☑️ (spvc-glsl/naga-glsl)         | ☑️ (naga-glsl)     |
+| HLSL        | ☑️ (spvc-hlsl/naga-hlsl)         | ☑️ (spvc-hlsl/naga-hlsl)         | ☑️ (spvc-hlsl/naga-hlsl)         | ☑️ (naga-hlsl)     |
+| Metal (MSL) | ☑️ (spvc-msl/naga-msl)           | ☑️ (spvc-msl/naga-msl)           | ☑️ (spvc-msl/naga-msl)           | ☑️ (naga-msl)      |
+| WGSL        | ☑️ (naga-wgsl)                   | ☑️ (naga-wgsl)                   | ☑️ (naga-wgsl)                   | ☑️ (naga-wgsl)     |
+| DXIL        | ❌                              | ❌                              | ❌                              | ❌                |
+| OpenCL C    | ❌                              | ❌                              | ❌                              | ❌                |
+| Cuda        | ❌                              | ❌                              | ❌                              | ❌                |
+| Validation  | ☑️ (spvt-validate/naga-validate) | ☑️ (spvt-validate/naga-validate) | ☑️ (spvt-validate/naga-validate) | ☑️ (naga-validate) |
 
 - ✅ Supported
-- ☑️ Supported on CLI, but library requires cargo feature(s)
+- ☑️ Supported, but library requires cargo feature(s)
 - ❌ Unsupported
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ wasm2spirv allows you to compile any WebAssembly program into a SPIR-V shader
 
 - Compiles your WebAssembly programs into SPIR-V
 - Can transpile into other various shading languages
-- Supports validation and optimization of the resulting SPIR-V via
-  [`spirv-tools`](https://github.com/EmbarkStudios/spirv-tools-rs)
+- Supports validation and optimization of the resulting SPIR-V
 - Can be compiled to WebAssembly itself
   - You won't be able to use `spirv-tools` or `spirv_cross` in WebAssembly
   - CLI will have to be compiled to WASI
@@ -55,6 +54,11 @@ wasm2spirv allows you to compile any WebAssembly program into a SPIR-V shader
 - ✅ Supported
 - ☑️ Supported, but library requires cargo feature(s)
 - ❌ Unsupported
+
+> **Note**\
+> The CLI programs built by the releases use the Khronos compilers/validators
+> whenever possible, faling back to naga compilers/validators if the Khronos are
+> not available or are not supported on that platform.
 
 ## Examples
 
@@ -387,9 +391,10 @@ kernel void main0(device _10& _12 [[buffer(0)]], device _14& _16 [[buffer(1)]], 
 ## Installation
 
 To add `wasm2spirv` as a library for your Rust project, run this command on
-you'r project's root directory: `cargo add wasm2spirv`
+you'r project's root directory.\
+`cargo add wasm2spirv`
 
-To install the latest version of the `wasm2spirv` CLI, run this command:
+To install the latest version of the `wasm2spirv` CLI, run this command.\
 `cargo install wasm2spirv`
 
 ## Cargo features

--- a/justfile
+++ b/justfile
@@ -8,8 +8,8 @@ clean:
 doc:
     cargo +nightly rustdoc --lib --open --all-features -- --cfg docsrs
 
-cli *ARGS:
-    cargo run --bin wasm2spirv --all-features -- {{ARGS}}
+cli COMPILER *ARGS:
+    cargo run --bin wasm2spirv --features="cli {{COMPILER}}" -- {{ARGS}}
 
 test TEST *ARGS:
     zig build-lib examples/{{TEST}}/{{TEST}}.zig -target wasm32-freestanding -O ReleaseSmall -femit-bin=examples/out/{{TEST}}.wasm -dynamic -rdynamic

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ clean:
     rm -rf examples/out/*
 
 doc:
-    cargo +nightly rustdoc --lib --open --all-features -- --cfg docsrs
+    cargo +nightly rustdoc --lib --open --features="khronos-all naga-wgsl" -- --cfg docsrs
 
 cli COMPILER *ARGS:
     cargo run --bin wasm2spirv --features="cli {{COMPILER}}" -- {{ARGS}}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,11 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     show_msl: bool,
 
+    /// Print Metal Shading Language (WGSL) translation on standard output
+    #[cfg(feature = "naga-wgsl")]
+    #[arg(long, default_value_t = false)]
+    show_wgsl: bool,
+
     /// Print text assembly on standard output
     #[arg(long, default_value_t = false)]
     show_asm: bool,
@@ -77,6 +82,8 @@ pub fn main() -> color_eyre::Result<()> {
         show_hlsl,
         #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
         show_msl,
+        #[cfg(feature = "naga-wgsl")]
+        show_wgsl,
     } = Cli::parse();
 
     if !quiet {
@@ -137,6 +144,11 @@ pub fn main() -> color_eyre::Result<()> {
     #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
     if show_msl {
         println!("{}", compilation.msl()?)
+    }
+
+    #[cfg(feature = "naga-wgsl")]
+    if show_wgsl {
+        println!("{}", compilation.wgsl()?)
     }
 
     return Ok(());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,22 +36,22 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     validate: bool,
 
-    /// Print GLSL translation on standard output
+    /// Print OpenGL Shading Language (GLSL) translation to standard output
     #[cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))]
     #[arg(long, default_value_t = false)]
     show_glsl: bool,
 
-    /// Print HLSL translation on standard output
+    /// Print High Level Shading Language (HLSL) translation to standard output
     #[cfg(any(feature = "spvc-hlsl", feature = "naga-hlsl"))]
     #[arg(long, default_value_t = false)]
     show_hlsl: bool,
 
-    /// Print Metal Shading Language (MSL) translation on standard output
+    /// Print Metal Shading Language (MSL) translation to standard output
     #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
     #[arg(long, default_value_t = false)]
     show_msl: bool,
 
-    /// Print Metal Shading Language (WGSL) translation on standard output
+    /// Print WebGPU Shading Language (WGSL) translation to standard output
     #[cfg(feature = "naga-wgsl")]
     #[arg(long, default_value_t = false)]
     show_wgsl: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use color_eyre::Report;
-use docfg::docfg;
 use std::{fs::File, io::BufReader, path::PathBuf};
 use wasm2spirv::{config::Config, Compilation};
 
@@ -33,7 +32,7 @@ struct Cli {
     optimize: bool,
 
     /// Validates the resulting SPIR-V
-    #[cfg(feature = "spirv-tools")]
+    #[cfg(any(feature = "naga-validate", feature = "spvt-validate"))]
     #[arg(long, default_value_t = false)]
     validate: bool,
 
@@ -73,7 +72,7 @@ pub fn main() -> color_eyre::Result<()> {
         quiet,
         #[cfg(feature = "spirv-tools")]
         optimize,
-        #[cfg(feature = "spirv-tools")]
+        #[cfg(any(feature = "naga-validate", feature = "spvt-validate"))]
         validate,
         show_asm,
         #[cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))]
@@ -112,7 +111,7 @@ pub fn main() -> color_eyre::Result<()> {
     let bytes = wat::parse_file(source)?;
     let mut compilation = Compilation::new(config, &bytes)?;
 
-    #[cfg(feature = "spirv-tools")]
+    #[cfg(any(feature = "naga-validate", feature = "spvt-validate"))]
     if validate {
         compilation.validate()?;
     }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -29,6 +29,21 @@ pub enum CompilerError {
     #[cfg_attr(docsrs, doc(cfg(feature = "naga-glsl")))]
     #[error("Naga GLSL error\n{0}")]
     NagaGlsl(Arc<::naga::back::glsl::Error>),
+
+    #[cfg(feature = "naga-hlsl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga-hlsl")))]
+    #[error("Naga HLSL error\n{0}")]
+    NagaHlsl(Arc<::naga::back::hlsl::Error>),
+
+    #[cfg(feature = "naga-msl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga-msl")))]
+    #[error("Naga MSL error\n{0}")]
+    NagaMsl(Arc<::naga::back::msl::Error>),
+
+    #[cfg(feature = "naga-wgsl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga-wgsl")))]
+    #[error("Naga Wgsl error\n{0}")]
+    NagaWgsl(Arc<::naga::back::wgsl::Error>),
 }
 
 #[docfg(feature = "naga")]
@@ -42,5 +57,26 @@ impl From<::naga::front::spv::Error> for CompilerError {
 impl From<::naga::back::glsl::Error> for CompilerError {
     fn from(value: ::naga::back::glsl::Error) -> Self {
         Self::NagaGlsl(Arc::new(value))
+    }
+}
+
+#[docfg(feature = "naga-hlsl")]
+impl From<::naga::back::hlsl::Error> for CompilerError {
+    fn from(value: ::naga::back::hlsl::Error) -> Self {
+        Self::NagaHlsl(Arc::new(value))
+    }
+}
+
+#[docfg(feature = "naga-msl")]
+impl From<::naga::back::msl::Error> for CompilerError {
+    fn from(value: ::naga::back::msl::Error) -> Self {
+        Self::NagaMsl(Arc::new(value))
+    }
+}
+
+#[docfg(feature = "naga-wgsl")]
+impl From<::naga::back::wgsl::Error> for CompilerError {
+    fn from(value: ::naga::back::wgsl::Error) -> Self {
+        Self::NagaWgsl(Arc::new(value))
     }
 }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "naga")]
+pub mod naga;
+
+#[cfg(feature = "spirv_cross")]
+pub mod spvc;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CompilerError {
+    #[cfg(feature = "spirv_cross")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "spirv_cross")))]
+    #[error("Spirv cross error")]
+    SpirvCross(#[from] spirv_cross::ErrorCode),
+
+    #[cfg(feature = "naga")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
+    #[error("Naga error")]
+    NagaValidation(#[from] naga::WithSpan<naga::valid::ValidationError>),
+
+    #[cfg(feature = "naga")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
+    #[error("Naga SPIR-V error")]
+    NagaSpv(#[from] naga::front::spv::Error),
+}

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -14,10 +14,15 @@ pub enum CompilerError {
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
     #[error("Naga error")]
-    NagaValidation(#[from] naga::WithSpan<naga::valid::ValidationError>),
+    NagaValidation(#[from] ::naga::WithSpan<::naga::valid::ValidationError>),
 
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
     #[error("Naga SPIR-V error")]
-    NagaSpv(#[from] naga::front::spv::Error),
+    NagaSpv(#[from] ::naga::front::spv::Error),
+
+    #[cfg(feature = "naga-glsl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "naga-glsl")))]
+    #[error("Naga GLSL error")]
+    NagaGlsl(#[from] ::naga::back::glsl::Error),
 }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -1,10 +1,14 @@
+use std::sync::Arc;
+
+use docfg::docfg;
+
 #[cfg(feature = "naga")]
 pub mod naga;
 
-#[cfg(feature = "spirv_cross")]
-pub mod spvc;
+// #[cfg(feature = "spirv_cross")]
+// pub mod spvc;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum CompilerError {
     #[cfg(feature = "spirv_cross")]
     #[cfg_attr(docsrs, doc(cfg(feature = "spirv_cross")))]
@@ -18,11 +22,25 @@ pub enum CompilerError {
 
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
-    #[error("Naga SPIR-V error")]
-    NagaSpv(#[from] ::naga::front::spv::Error),
+    #[error("Naga SPIR-V error\n{0}")]
+    NagaSpv(Arc<::naga::front::spv::Error>),
 
     #[cfg(feature = "naga-glsl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga-glsl")))]
-    #[error("Naga GLSL error")]
-    NagaGlsl(#[from] ::naga::back::glsl::Error),
+    #[error("Naga GLSL error\n{0}")]
+    NagaGlsl(Arc<::naga::back::glsl::Error>),
+}
+
+#[docfg(feature = "naga")]
+impl From<::naga::front::spv::Error> for CompilerError {
+    fn from(value: ::naga::front::spv::Error) -> Self {
+        Self::NagaSpv(Arc::new(value))
+    }
+}
+
+#[docfg(feature = "naga-glsl")]
+impl From<::naga::back::glsl::Error> for CompilerError {
+    fn from(value: ::naga::back::glsl::Error) -> Self {
+        Self::NagaGlsl(Arc::new(value))
+    }
 }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -1,12 +1,14 @@
-use std::sync::Arc;
-
 use docfg::docfg;
+use std::sync::Arc;
 
 #[cfg(feature = "naga")]
 pub mod naga;
 
-// #[cfg(feature = "spirv_cross")]
-// pub mod spvc;
+#[cfg(feature = "spirv_cross")]
+pub mod spvc;
+
+#[cfg(feature = "spirv-tools")]
+pub mod spvt;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum CompilerError {
@@ -17,7 +19,7 @@ pub enum CompilerError {
 
     #[cfg(feature = "naga")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga")))]
-    #[error("Naga error")]
+    #[error("Naga validation error")]
     NagaValidation(#[from] ::naga::WithSpan<::naga::valid::ValidationError>),
 
     #[cfg(feature = "naga")]
@@ -42,7 +44,7 @@ pub enum CompilerError {
 
     #[cfg(feature = "naga-wgsl")]
     #[cfg_attr(docsrs, doc(cfg(feature = "naga-wgsl")))]
-    #[error("Naga Wgsl error\n{0}")]
+    #[error("Naga WGSL error\n{0}")]
     NagaWgsl(Arc<::naga::back::wgsl::Error>),
 }
 

--- a/src/compilers/naga.rs
+++ b/src/compilers/naga.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Error, Result},
     Compilation,
 };
-use naga::{back::glsl::PipelineOptions, proc::BoundsCheckPolicies, valid};
+use naga::{proc::BoundsCheckPolicies, valid};
 use rspirv::dr::Operand;
 use spirv::{ExecutionModel, Op};
 
@@ -36,7 +36,7 @@ impl Compilation {
             let (exec_model, name) = self.naga_info()?;
             let (module, info) = self.naga_module()?;
 
-            let pipeline_options = PipelineOptions {
+            let pipeline_options = glsl::PipelineOptions {
                 shader_stage: match exec_model {
                     ExecutionModel::Vertex => naga::ShaderStage::Vertex,
                     ExecutionModel::Fragment => naga::ShaderStage::Fragment,

--- a/src/compilers/naga.rs
+++ b/src/compilers/naga.rs
@@ -16,6 +16,16 @@ macro_rules! tri {
 }
 
 impl Compilation {
+    #[cfg(feature = "naga-validate")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "spvt-validate", feature = "naga-validate")))
+    )]
+    pub fn validate(&self) -> Result<()> {
+        let _ = self.naga_module()?;
+        return Ok(());
+    }
+
     #[cfg(feature = "naga-glsl")]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))))]
     pub fn glsl(&self) -> Result<&str> {
@@ -134,7 +144,7 @@ impl Compilation {
             ));
 
             let info = tri!(valid::Validator::new(
-                valid::ValidationFlags::empty(),
+                valid::ValidationFlags::all(),
                 valid::Capabilities::all()
             )
             .validate(&module));

--- a/src/compilers/naga.rs
+++ b/src/compilers/naga.rs
@@ -1,0 +1,44 @@
+use crate::Compilation;
+use docfg::docfg;
+use naga::valid;
+use std::io::Cursor;
+
+impl Compilation {
+    #[docfg(feature = "naga-glsl")]
+    pub fn glsl(&self) -> Result<&str> {
+        use naga::back::glsl;
+
+        match self.glsl.get_or_try_init(|| {
+            let module = self.naga_module()?;
+            let info =
+                valid::Validator::new(valid::ValidationFlags::all(), valid::Capabilities::all())
+                    .validate(&module)?;
+
+            let varsion = match 0 {
+                _ => naga::back::glsl::Version::Desktop(450),
+            };
+
+            let options = glsl::Options {
+                version,
+                ..Default::default()
+            };
+
+            let mut result = Cursor::new(Vec::<u8>::new());
+            let mut writer = naga::back::glsl::Writer::new(&mut result, &module, &info, &options);
+
+            match spirv::Ast::<glsl::Target>::parse(&module) {
+                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Err(e) => Ok(Err(e)),
+            }
+        })? {
+            Ok(str) => Ok(str),
+            Err(e) => Err(Error::from(e.clone())),
+        }
+    }
+
+    fn naga_module(&self) -> Result<naga::Module> {
+        let module =
+            naga::front::spv::parse_u8_slice(self.bytes()?, &naga::front::spv::Options::default())?;
+        return Ok(module);
+    }
+}

--- a/src/compilers/naga.rs
+++ b/src/compilers/naga.rs
@@ -1,20 +1,54 @@
-use crate::Compilation;
-use docfg::docfg;
-use naga::valid;
+use crate::{
+    error::{Error, Result},
+    Compilation,
+};
+use naga::{back::glsl::PipelineOptions, proc::BoundsCheckPolicies, valid};
+use rspirv::dr::Operand;
+use spirv::{ExecutionModel, Op};
 use std::io::Cursor;
 
+use super::CompilerError;
+
+macro_rules! tri {
+    ($e:expr) => {
+        match $e {
+            Ok(x) => x,
+            Err(e) => return Ok(Err(e.into())),
+        }
+    };
+}
+
 impl Compilation {
-    #[docfg(feature = "naga-glsl")]
+    #[cfg(feature = "naga-glsl")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))))]
     pub fn glsl(&self) -> Result<&str> {
         use naga::back::glsl;
 
         match self.glsl.get_or_try_init(|| {
-            let module = self.naga_module()?;
-            let info =
-                valid::Validator::new(valid::ValidationFlags::all(), valid::Capabilities::all())
-                    .validate(&module)?;
+            let (exec_model, name) = self.naga_info()?;
+            let pipeline_options = PipelineOptions {
+                shader_stage: match exec_model {
+                    ExecutionModel::Vertex => naga::ShaderStage::Vertex,
+                    ExecutionModel::Fragment => naga::ShaderStage::Fragment,
+                    ExecutionModel::GLCompute => naga::ShaderStage::Compute,
+                    other => {
+                        return Err(Error::msg(format!(
+                            "Unsupported execution model '{other:?}'"
+                        )))
+                    }
+                },
+                entry_point: name.to_string(),
+                multiview: None,
+            };
 
-            let varsion = match 0 {
+            let module = self.naga_module()?;
+            let info = tri!(valid::Validator::new(
+                valid::ValidationFlags::all(),
+                valid::Capabilities::all()
+            )
+            .validate(&module));
+
+            let version = match 0 {
                 _ => naga::back::glsl::Version::Desktop(450),
             };
 
@@ -24,21 +58,47 @@ impl Compilation {
             };
 
             let mut result = Cursor::new(Vec::<u8>::new());
-            let mut writer = naga::back::glsl::Writer::new(&mut result, &module, &info, &options);
+            let mut writer = naga::back::glsl::Writer::new(
+                &mut result,
+                &module,
+                &info,
+                &options,
+                &pipeline_options,
+                BoundsCheckPolicies::default(),
+            );
 
-            match spirv::Ast::<glsl::Target>::parse(&module) {
-                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
-                Err(e) => Ok(Err(e)),
-            }
+            writer.write()?;
+            let result = String::from_utf8(result.into_inner())?;
+            Ok(Ok(result.into_boxed_str()))
         })? {
             Ok(str) => Ok(str),
             Err(e) => Err(Error::from(e.clone())),
         }
     }
 
-    fn naga_module(&self) -> Result<naga::Module> {
+    fn naga_module(&self) -> Result<naga::Module, CompilerError> {
         let module =
             naga::front::spv::parse_u8_slice(self.bytes()?, &naga::front::spv::Options::default())?;
         return Ok(module);
+    }
+
+    fn naga_info(&self) -> Result<(ExecutionModel, &str)> {
+        let module = self.module()?;
+        if module.entry_points.len() != 1 {
+            return Err(Error::msg("Exactly one entry point must be specified"));
+        }
+
+        let entry_point = &module.entry_points[0];
+        debug_assert_eq!(entry_point.class.opcode, Op::EntryPoint);
+
+        let execution_model = match entry_point.operands.get(0) {
+            Some(Operand::ExecutionModel(model)) => model,
+            _ => return Err(Error::unexpected()),
+        };
+
+        let name = match entry_point.operands.get(2) {
+            Some(Operand::LiteralString(mode)) => mode,
+            _ => return Err(Error::unexpected()),
+        };
     }
 }

--- a/src/compilers/spvc.rs
+++ b/src/compilers/spvc.rs
@@ -1,8 +1,10 @@
+use crate::error::{Error, Result};
 use crate::Compilation;
 use docfg::docfg;
 
 impl Compilation {
-    #[docfg(feature = "spvc-glsl")]
+    #[cfg(feature = "spvc-glsl")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))))]
     pub fn glsl(&self) -> Result<&str> {
         use spirv_cross::{glsl, spirv};
 

--- a/src/compilers/spvc.rs
+++ b/src/compilers/spvc.rs
@@ -11,7 +11,11 @@ impl Compilation {
         match self.glsl.get_or_try_init(|| {
             let module = spirv::Module::from_words(self.words()?);
             match spirv::Ast::<glsl::Target>::parse(&module) {
-                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Ok(mut ast) => Ok::<_, Error>(
+                    ast.compile()
+                        .map(String::into_boxed_str)
+                        .map_err(Into::into),
+                ),
                 Err(e) => Ok(Err(e.into())),
             }
         })? {
@@ -20,14 +24,19 @@ impl Compilation {
         }
     }
 
-    #[docfg(feature = "spvc-hlsl")]
+    #[cfg(feature = "spvc-hlsl")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "spvc-hlsl", feature = "naga-hlsl"))))]
     pub fn hlsl(&self) -> Result<&str> {
         use spirv_cross::{hlsl, spirv};
 
         match self.hlsl.get_or_try_init(|| {
             let module = spirv::Module::from_words(self.words()?);
             match spirv::Ast::<hlsl::Target>::parse(&module) {
-                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Ok(mut ast) => Ok::<_, Error>(
+                    ast.compile()
+                        .map(String::into_boxed_str)
+                        .map_err(Into::into),
+                ),
                 Err(e) => Ok(Err(e.into())),
             }
         })? {
@@ -36,14 +45,19 @@ impl Compilation {
         }
     }
 
-    #[docfg(feature = "spvc-msl")]
+    #[cfg(feature = "spvc-msl")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "spvc-msl", feature = "naga-msl"))))]
     pub fn msl(&self) -> Result<&str> {
         use spirv_cross::{msl, spirv};
 
         match self.msl.get_or_try_init(|| {
             let module = spirv::Module::from_words(self.words()?);
             match spirv::Ast::<msl::Target>::parse(&module) {
-                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Ok(mut ast) => Ok::<_, Error>(
+                    ast.compile()
+                        .map(String::into_boxed_str)
+                        .map_err(Into::into),
+                ),
                 Err(e) => Ok(Err(e.into())),
             }
         })? {

--- a/src/compilers/spvc.rs
+++ b/src/compilers/spvc.rs
@@ -1,0 +1,52 @@
+use crate::Compilation;
+use docfg::docfg;
+
+impl Compilation {
+    #[docfg(feature = "spvc-glsl")]
+    pub fn glsl(&self) -> Result<&str> {
+        use spirv_cross::{glsl, spirv};
+
+        match self.glsl.get_or_try_init(|| {
+            let module = spirv::Module::from_words(self.words()?);
+            match spirv::Ast::<glsl::Target>::parse(&module) {
+                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Err(e) => Ok(Err(e.into())),
+            }
+        })? {
+            Ok(str) => Ok(str),
+            Err(e) => Err(Error::from(e.clone())),
+        }
+    }
+
+    #[docfg(feature = "spvc-hlsl")]
+    pub fn hlsl(&self) -> Result<&str> {
+        use spirv_cross::{hlsl, spirv};
+
+        match self.hlsl.get_or_try_init(|| {
+            let module = spirv::Module::from_words(self.words()?);
+            match spirv::Ast::<hlsl::Target>::parse(&module) {
+                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Err(e) => Ok(Err(e.into())),
+            }
+        })? {
+            Ok(str) => Ok(str),
+            Err(e) => Err(Error::from(e.clone())),
+        }
+    }
+
+    #[docfg(feature = "spvc-msl")]
+    pub fn msl(&self) -> Result<&str> {
+        use spirv_cross::{msl, spirv};
+
+        match self.msl.get_or_try_init(|| {
+            let module = spirv::Module::from_words(self.words()?);
+            match spirv::Ast::<msl::Target>::parse(&module) {
+                Ok(mut ast) => Ok::<_, Error>(ast.compile().map(String::into_boxed_str)),
+                Err(e) => Ok(Err(e.into())),
+            }
+        })? {
+            Ok(str) => Ok(str),
+            Err(e) => Err(Error::from(e.clone())),
+        }
+    }
+}

--- a/src/compilers/spvt.rs
+++ b/src/compilers/spvt.rs
@@ -1,0 +1,105 @@
+use crate::error::{Error, Result};
+use crate::Compilation;
+use docfg::docfg;
+use once_cell::unsync::OnceCell;
+use std::mem::ManuallyDrop;
+
+impl Compilation {
+    #[cfg(feature = "spvt-validate")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "spvt-validate", feature = "naga-validate")))
+    )]
+    pub fn validate(&self) -> Result<()> {
+        use spirv_tools::val::Validator;
+
+        let res = self.validate.get_or_try_init(|| {
+            let validator = spirv_tools::val::create(Some(self.target_env));
+            Ok::<_, Error>(validator.validate(self.words()?, None).err())
+        })?;
+
+        return match res {
+            Some(err) => Err(Error::from(clone_error(err))),
+            None => Ok(()),
+        };
+    }
+
+    #[docfg(feature = "spirv-tools")]
+    pub fn into_optimized(self) -> Result<Self> {
+        use spirv_tools::opt::Optimizer;
+
+        let optimizer = spirv_tools::opt::create(Some(self.target_env));
+        let words = match optimizer.optimize(self.words()?, &mut spirv_tools_message, None)? {
+            spirv_tools::binary::Binary::External(words) => AsRef::<[u32]>::as_ref(&words).into(),
+            spirv_tools::binary::Binary::OwnedU32(words) => words,
+            spirv_tools::binary::Binary::OwnedU8(bytes) => {
+                match bytes.as_ptr().align_offset(core::mem::align_of::<u32>()) {
+                    0 if bytes.len() % 4 == 0 && bytes.capacity() % 4 == 0 => unsafe {
+                        let mut bytes = ManuallyDrop::new(bytes);
+                        Vec::from_raw_parts(
+                            bytes.as_mut_ptr().cast(),
+                            bytes.len() / 4,
+                            bytes.capacity() / 4,
+                        )
+                    },
+                    _ => {
+                        let mut result = Vec::with_capacity(bytes.len() / 4);
+                        for chunk in bytes.chunks_exact(4) {
+                            let chunk = unsafe { TryFrom::try_from(chunk).unwrap_unchecked() };
+                            result.push(u32::from_ne_bytes(chunk));
+                        }
+                        result
+                    }
+                }
+            }
+        };
+
+        return Ok(Self {
+            module: OnceCell::new(),
+            #[cfg(feature = "naga")]
+            naga_module: OnceCell::new(),
+            words: OnceCell::with_value(words.into_boxed_slice()),
+            #[cfg(feature = "spirv-tools")]
+            target_env: self.target_env,
+            assembly: OnceCell::new(),
+            #[cfg(feature = "spirv_cross")]
+            glsl: OnceCell::new(),
+            #[cfg(feature = "spirv_cross")]
+            hlsl: OnceCell::new(),
+            #[cfg(feature = "spirv_cross")]
+            msl: OnceCell::new(),
+            #[cfg(feature = "naga-wgsl")]
+            wgsl: OnceCell::new(),
+            #[cfg(feature = "spirv-tools")]
+            validate: OnceCell::new(),
+        });
+    }
+}
+
+fn clone_diagnostics(diag: &spirv_tools::error::Diagnostic) -> spirv_tools::error::Diagnostic {
+    return spirv_tools::error::Diagnostic {
+        line: diag.line,
+        column: diag.column,
+        index: diag.index,
+        message: diag.message.clone(),
+        is_text: diag.is_text,
+    };
+}
+
+fn clone_error(err: &spirv_tools::error::Error) -> spirv_tools::error::Error {
+    return spirv_tools::error::Error {
+        inner: err.inner,
+        diagnostic: err.diagnostic.as_ref().map(clone_diagnostics),
+    };
+}
+
+fn spirv_tools_message(msg: spirv_tools::error::Message) {
+    match msg.level {
+        spirv_tools::error::MessageLevel::Fatal
+        | spirv_tools::error::MessageLevel::InternalError
+        | spirv_tools::error::MessageLevel::Error => tracing::error!("{}", msg.message),
+        spirv_tools::error::MessageLevel::Warning => tracing::warn!("{}", msg.message),
+        spirv_tools::error::MessageLevel::Info => tracing::info!("{}", msg.message),
+        spirv_tools::error::MessageLevel::Debug => tracing::debug!("{}", msg.message),
+    };
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     #[error("Compiler error")]
     Compiler(#[from] compilers::CompilerError),
 
+    #[error("Utf-8 parsing error")]
+    Utf8(#[from] std::str::Utf8Error),
+
     #[cfg(feature = "spirv-tools")]
     #[cfg_attr(docsrs, doc(cfg(feature = "spirv-tools")))]
     #[error("Spirv tools error")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use std::error::Error as StdError;
 use std::fmt::Display;
 use std::{backtrace::Backtrace, borrow::Borrow, fmt::Debug, num::ParseIntError};
 
+use crate::compilers;
+
 pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
@@ -12,7 +14,7 @@ pub enum Error {
     #[error("WebAssembly text parsing error")]
     Wat(#[from] wat::Error),
 
-    #[error("Spir-v error")]
+    #[error("SPIR-V error")]
     Spirv(#[from] rspirv::dr::Error),
 
     #[error("Int parsing error")]
@@ -21,15 +23,13 @@ pub enum Error {
     #[error("I/O error")]
     Io(#[from] std::io::Error),
 
+    #[error("Compiler error")]
+    Compiler(#[from] compilers::CompilerError),
+
     #[cfg(feature = "spirv-tools")]
     #[cfg_attr(docsrs, doc(cfg(feature = "spirv-tools")))]
     #[error("Spirv tools error")]
     SpirvTools(#[from] spirv_tools::error::Error),
-
-    #[cfg(feature = "spirv_cross")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "spirv_cross")))]
-    #[error("Spirv cross error")]
-    SpirvCross(#[from] spirv_cross::ErrorCode),
 
     #[error("Custom error")]
     Custom(#[from] Box<dyn 'static + Send + Sync + StdError>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub mod version;
 
 pub struct Compilation {
     module: OnceCell<Result<Module, ParseState>>,
+    #[cfg(feature = "naga")]
+    naga_module:
+        OnceCell<Result<(naga::Module, naga::valid::ModuleInfo), compilers::CompilerError>>,
     #[cfg(feature = "spirv-tools")]
     target_env: spirv_tools::TargetEnv,
     assembly: OnceCell<Box<str>>,
@@ -45,6 +48,8 @@ pub struct Compilation {
     hlsl: OnceCell<Result<Box<str>, compilers::CompilerError>>,
     #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
     msl: OnceCell<Result<Box<str>, compilers::CompilerError>>,
+    #[cfg(feature = "naga-wgsl")]
+    wgsl: OnceCell<Result<Box<str>, compilers::CompilerError>>,
     #[cfg(feature = "spirv-tools")]
     validate: OnceCell<Option<spirv_tools::error::Error>>,
 }
@@ -58,6 +63,8 @@ impl Compilation {
 
         return Ok(Self {
             module: OnceCell::with_value(Ok(module)),
+            #[cfg(feature = "naga")]
+            naga_module: OnceCell::new(),
             #[cfg(feature = "spirv-tools")]
             target_env,
             assembly: OnceCell::new(),
@@ -68,6 +75,8 @@ impl Compilation {
             hlsl: OnceCell::new(),
             #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
             msl: OnceCell::new(),
+            #[cfg(feature = "naga-wgsl")]
+            wgsl: OnceCell::new(),
             #[cfg(feature = "spirv-tools")]
             validate: OnceCell::new(),
         });
@@ -152,6 +161,8 @@ impl Compilation {
 
         return Ok(Self {
             module: OnceCell::new(),
+            #[cfg(feature = "naga")]
+            naga_module: OnceCell::new(),
             words: OnceCell::with_value(words.into_boxed_slice()),
             #[cfg(feature = "spirv-tools")]
             target_env: self.target_env,
@@ -162,6 +173,8 @@ impl Compilation {
             hlsl: OnceCell::new(),
             #[cfg(feature = "spirv_cross")]
             msl: OnceCell::new(),
+            #[cfg(feature = "naga-wgsl")]
+            wgsl: OnceCell::new(),
             #[cfg(feature = "spirv-tools")]
             validate: OnceCell::new(),
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ use std::{
     ops::Deref,
 };
 
+#[cfg(all(feature = "spvc-validate", feature = "naga-validate"))]
+compile_error!("You can't select both SPIRV-Tools and Naga validators. Only one can be enabled at the same time");
 #[cfg(all(feature = "spvc-glsl", feature = "naga-glsl"))]
 compile_error!("You can't select both SPIRV-Cross and Naga compilers for GLSL. Only one can be enabled at the same time");
 #[cfg(all(feature = "spvc-hlsl", feature = "naga-hlsl"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,11 @@ impl Compilation {
             target_env,
             assembly: OnceCell::new(),
             words: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
+            #[cfg(any(feature = "spvc-glsl", feature = "naga-glsl"))]
             glsl: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
+            #[cfg(any(feature = "spvc-hlsl", feature = "naga-hlsl"))]
             hlsl: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
+            #[cfg(any(feature = "spvc-msl", feature = "naga-msl"))]
             msl: OnceCell::new(),
             #[cfg(feature = "spirv-tools")]
             validate: OnceCell::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,12 @@ use std::{
     ops::Deref,
 };
 
-// #[cfg(all(feature = "spvc-glsl", feature = "naga-glsl"))]
-// compile_error!("You can't select both SPIRV-Cross and Naga compilers for GLSL. Only one can be enabled at the same time");
-// #[cfg(all(feature = "spvc-hlsl", feature = "naga-hlsl"))]
-// compile_error!("You can't select both SPIRV-Cross and Naga compilers for HLSL. Only one can be enabled at the same time");
-// #[cfg(all(feature = "spvc-msl", feature = "naga-msl"))]
-// compile_error!("You can't select both SPIRV-Cross and Naga compilers for MSL. Only one can be enabled at the same time");
+#[cfg(all(feature = "spvc-glsl", feature = "naga-glsl"))]
+compile_error!("You can't select both SPIRV-Cross and Naga compilers for GLSL. Only one can be enabled at the same time");
+#[cfg(all(feature = "spvc-hlsl", feature = "naga-hlsl"))]
+compile_error!("You can't select both SPIRV-Cross and Naga compilers for HLSL. Only one can be enabled at the same time");
+#[cfg(all(feature = "spvc-msl", feature = "naga-msl"))]
+compile_error!("You can't select both SPIRV-Cross and Naga compilers for MSL. Only one can be enabled at the same time");
 
 // pub mod binary;
 pub mod compilers;
@@ -50,7 +50,7 @@ pub struct Compilation {
     msl: OnceCell<Result<Box<str>, compilers::CompilerError>>,
     #[cfg(feature = "naga-wgsl")]
     wgsl: OnceCell<Result<Box<str>, compilers::CompilerError>>,
-    #[cfg(feature = "spirv-tools")]
+    #[cfg(feature = "spvt-validate")]
     validate: OnceCell<Option<spirv_tools::error::Error>>,
 }
 
@@ -111,72 +111,6 @@ impl Compilation {
         let words = self.words()?;
         return Ok(unsafe {
             core::slice::from_raw_parts(words.as_ptr().cast(), size_of::<u32>() * words.len())
-        });
-    }
-
-    #[docfg(feature = "spirv-tools")]
-    pub fn validate(&self) -> Result<()> {
-        use spirv_tools::val::Validator;
-
-        let res = self.validate.get_or_try_init(|| {
-            let validator = spirv_tools::val::create(Some(self.target_env));
-            Ok::<_, Error>(validator.validate(self.words()?, None).err())
-        })?;
-
-        return match res {
-            Some(err) => Err(Error::from(clone_error(err))),
-            None => Ok(()),
-        };
-    }
-
-    #[docfg(feature = "spirv-tools")]
-    pub fn into_optimized(self) -> Result<Self> {
-        use spirv_tools::opt::Optimizer;
-
-        let optimizer = spirv_tools::opt::create(Some(self.target_env));
-        let words = match optimizer.optimize(self.words()?, &mut spirv_tools_message, None)? {
-            spirv_tools::binary::Binary::External(words) => AsRef::<[u32]>::as_ref(&words).into(),
-            spirv_tools::binary::Binary::OwnedU32(words) => words,
-            spirv_tools::binary::Binary::OwnedU8(bytes) => {
-                match bytes.as_ptr().align_offset(core::mem::align_of::<u32>()) {
-                    0 if bytes.len() % 4 == 0 && bytes.capacity() % 4 == 0 => unsafe {
-                        let mut bytes = ManuallyDrop::new(bytes);
-                        Vec::from_raw_parts(
-                            bytes.as_mut_ptr().cast(),
-                            bytes.len() / 4,
-                            bytes.capacity() / 4,
-                        )
-                    },
-                    _ => {
-                        let mut result = Vec::with_capacity(bytes.len() / 4);
-                        for chunk in bytes.chunks_exact(4) {
-                            let chunk = unsafe { TryFrom::try_from(chunk).unwrap_unchecked() };
-                            result.push(u32::from_ne_bytes(chunk));
-                        }
-                        result
-                    }
-                }
-            }
-        };
-
-        return Ok(Self {
-            module: OnceCell::new(),
-            #[cfg(feature = "naga")]
-            naga_module: OnceCell::new(),
-            words: OnceCell::with_value(words.into_boxed_slice()),
-            #[cfg(feature = "spirv-tools")]
-            target_env: self.target_env,
-            assembly: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
-            glsl: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
-            hlsl: OnceCell::new(),
-            #[cfg(feature = "spirv_cross")]
-            msl: OnceCell::new(),
-            #[cfg(feature = "naga-wgsl")]
-            wgsl: OnceCell::new(),
-            #[cfg(feature = "spirv-tools")]
-            validate: OnceCell::new(),
         });
     }
 
@@ -270,35 +204,4 @@ impl<'a> From<Str<'a>> for String {
             Str::Borrowed(x) => String::from(x),
         }
     }
-}
-
-#[cfg(feature = "spirv-tools")]
-fn clone_diagnostics(diag: &spirv_tools::error::Diagnostic) -> spirv_tools::error::Diagnostic {
-    return spirv_tools::error::Diagnostic {
-        line: diag.line,
-        column: diag.column,
-        index: diag.index,
-        message: diag.message.clone(),
-        is_text: diag.is_text,
-    };
-}
-
-#[cfg(feature = "spirv-tools")]
-fn clone_error(err: &spirv_tools::error::Error) -> spirv_tools::error::Error {
-    return spirv_tools::error::Error {
-        inner: err.inner,
-        diagnostic: err.diagnostic.as_ref().map(clone_diagnostics),
-    };
-}
-
-#[cfg(feature = "spirv-tools")]
-fn spirv_tools_message(msg: spirv_tools::error::Message) {
-    match msg.level {
-        spirv_tools::error::MessageLevel::Fatal
-        | spirv_tools::error::MessageLevel::InternalError
-        | spirv_tools::error::MessageLevel::Error => tracing::error!("{}", msg.message),
-        spirv_tools::error::MessageLevel::Warning => tracing::warn!("{}", msg.message),
-        spirv_tools::error::MessageLevel::Info => tracing::info!("{}", msg.message),
-        spirv_tools::error::MessageLevel::Debug => tracing::debug!("{}", msg.message),
-    };
 }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1061,7 +1061,7 @@ impl Translation for &Label {
     fn translate(
         self,
         _: &ModuleBuilder,
-        function: Option<&FunctionBuilder>,
+        _: Option<&FunctionBuilder>,
         builder: &mut Builder,
     ) -> Result<rspirv::spirv::Word> {
         if let Some(res) = self.translation.get() {


### PR DESCRIPTION
I thought it would be fitting that the wasm to spirv compiler could run it's CLI with WebAssembly, so I made it possible.
To do so, I also implemented support for the [Naga](https://github.com/gfx-rs/naga/) compiler, which can compile to GLSL, HLSL, MSL & WGSL and can be compiled to WebAssebly (unlike spirv-tools & spirv_cross).