### PR TITLE
Add extra logical instructions and float comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
 name = "wasm2spirv"
 version = "0.1.1"
 dependencies = [
+ "cfg-if",
  "clap",
  "color-eyre",
  "docfg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ path = "src/cli.rs"
 required-features = ["clap", "color-eyre", "serde_json"]
 
 [dependencies]
+cfg-if = "1.0.0"
 clap = { version = "4.3.19", optional = true, features = ["derive", "env"] }
 color-eyre = { version = "0.6.2", optional = true }
 docfg = "0.1.0"

--- a/examples/min/min.json
+++ b/examples/min/min.json
@@ -1,0 +1,70 @@
+{
+    "platform": {
+        "vulkan": "1.1"
+    },
+    "version": "1.3",
+    "addressing_model": "logical",
+    "memory_model": "GLSL450",
+    "capabilities": { "dynamic": [] },
+    "extensions": [],
+    "functions": {
+        "2": {
+            "execution_model": "GLCompute",
+            "execution_mode": {
+                "local_size": [1, 1, 1]
+            },
+            "params": {
+                "0": {
+                    "type": {
+                        "Structured": "i32"
+                    },
+                    "kind": {
+                        "descriptor_set": {
+                            "storage_class": "StorageBuffer",
+                            "set": 0,
+                            "binding": 0
+                        }
+                    }
+                },
+                "1": {
+                    "type": {
+                        "Structured": "f32"
+                    },
+                    "kind": {
+                        "descriptor_set": {
+                            "storage_class": "StorageBuffer",
+                            "set": 0,
+                            "binding": 1
+                        }
+                    }
+                },
+                "2": {
+                    "type": {
+                        "StructuredArray": "f32"
+                    },
+                    "kind": {
+                        "descriptor_set": {
+                            "storage_class": "StorageBuffer",
+                            "set": 0,
+                            "binding": 2
+                        }
+                    },
+                    "is_extern_pointer": true
+                },
+                "3": {
+                    "type": {
+                        "StructuredArray": "f32"
+                    },
+                    "kind": {
+                        "descriptor_set": {
+                            "storage_class": "StorageBuffer",
+                            "set": 0,
+                            "binding": 3
+                        }
+                    },
+                    "is_extern_pointer": true
+                }
+            }
+        }
+    }
+}

--- a/examples/min/min.wat
+++ b/examples/min/min.wat
@@ -1,0 +1,55 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (type (;1;) (func (param i32 f32 i32 i32)))
+  (type (;2;) (func (param f32 f32) (result f32)))
+  (import "spir_global" "gl_GlobalInvocationID" (func (;0;) (type 0)))
+  (import "spir_global" "gl_NumWorkGroups" (func (;1;) (type 0)))
+  (func (;2;) (type 1) (param i32 f32 i32 i32)
+    (local i32 i32 i32 i32 i32)
+    i32.const 0
+    call 0
+    local.tee 4
+    i32.const 2
+    i32.shl
+    local.set 5
+    i32.const 0
+    call 1
+    local.tee 6
+    i32.const 2
+    i32.shl
+    local.set 7
+    block  ;; label = @1
+      loop  ;; label = @2
+        local.get 4
+        local.get 0
+        i32.ge_u
+        br_if 1 (;@1;)
+        local.get 3
+        local.get 5
+        i32.add
+        local.tee 8
+        local.get 8
+        f32.load
+        local.get 1
+        local.get 2
+        local.get 5
+        i32.add
+        f32.load
+        f32.min
+        f32.add
+        f32.store
+        local.get 5
+        local.get 7
+        i32.add
+        local.set 5
+        local.get 4
+        local.get 6
+        i32.add
+        local.set 4
+        br 0 (;@2;)
+      end
+    end)
+  (memory (;0;) 16)
+  (global (;0;) (mut i32) (i32.const 1048576))
+  (export "memory" (memory 0))
+  (export "main" (func 2)))

--- a/examples/min/min.zig
+++ b/examples/min/min.zig
@@ -1,0 +1,12 @@
+export fn main(n: usize, alpha: f32, x: [*]const f32, y: [*]f32) void {
+    var i = gl_GlobalInvocationID(0);
+    const size = gl_NumWorkGroups(0);
+
+    while (i < n) {
+        y[i] += @min(alpha, x[i]);
+        i += size;
+    }
+}
+
+extern "spir_global" fn gl_GlobalInvocationID(u32) usize;
+extern "spir_global" fn gl_NumWorkGroups(u32) usize;

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ cli COMPILER *ARGS:
 
 test TEST *ARGS:
     zig build-lib examples/{{TEST}}/{{TEST}}.zig -target wasm32-freestanding -O ReleaseSmall -femit-bin=examples/out/{{TEST}}.wasm -dynamic -rdynamic
-    just cli examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
+    just cli naga-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
 
 test-wat TEST *ARGS:
     just cli examples/{{TEST}}/{{TEST}}.wat --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -13,10 +13,10 @@ cli COMPILER *ARGS:
 
 test TEST *ARGS:
     zig build-lib examples/{{TEST}}/{{TEST}}.zig -target wasm32-freestanding -O ReleaseSmall -femit-bin=examples/out/{{TEST}}.wasm -dynamic -rdynamic
-    just cli naga-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
+    just cli khronos-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
 
 test-wat TEST *ARGS:
-    just cli examples/{{TEST}}/{{TEST}}.wat --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
+    just cli khronos-all examples/{{TEST}}/{{TEST}}.wat --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
 
 test-publish *ARGS:
     cargo publish --dry-run --allow-dirty {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ cli COMPILER *ARGS:
 
 test TEST *ARGS:
     zig build-lib examples/{{TEST}}/{{TEST}}.zig -target wasm32-freestanding -O ReleaseSmall -femit-bin=examples/out/{{TEST}}.wasm -dynamic -rdynamic
-    just cli khronos-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
+    just cli naga-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
 
 test-wat TEST *ARGS:
     just cli examples/{{TEST}}/{{TEST}}.wat --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ cli COMPILER *ARGS:
 
 test TEST *ARGS:
     zig build-lib examples/{{TEST}}/{{TEST}}.zig -target wasm32-freestanding -O ReleaseSmall -femit-bin=examples/out/{{TEST}}.wasm -dynamic -rdynamic
-    just cli naga-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
+    just cli khronos-all examples/out/{{TEST}}.wasm --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}
 
 test-wat TEST *ARGS:
     just cli examples/{{TEST}}/{{TEST}}.wat --from-json examples/{{TEST}}/{{TEST}}.json -o examples/out/{{TEST}}.spv {{ARGS}}

--- a/src/compilers/naga.rs
+++ b/src/compilers/naga.rs
@@ -138,10 +138,11 @@ impl Compilation {
 
     fn naga_module(&self) -> Result<&(naga::Module, naga::valid::ModuleInfo)> {
         match self.naga_module.get_or_try_init(|| {
-            let module = tri!(naga::front::spv::parse_u8_slice(
-                self.bytes()?,
-                &naga::front::spv::Options::default()
-            ));
+            let options = &naga::front::spv::Options::default();
+            let module =
+                tri!(
+                    naga::front::spv::Frontend::new(self.words()?.iter().copied(), options).parse()
+                );
 
             let info = tri!(valid::Validator::new(
                 valid::ValidationFlags::all(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#![allow(non_upper_case_globals)]
+
 use crate::{
     error::{Error, Result},
     fg::function::{FunctionConfig, FunctionConfigBuilder},
@@ -9,7 +11,7 @@ use num_enum::TryFromPrimitive;
 use rspirv::spirv::{Capability, MemoryModel, StorageClass};
 use serde::{Deserialize, Serialize};
 use spirv::ExecutionModel;
-use std::{cell::RefCell, ops::Deref};
+use std::cell::RefCell;
 use vector_mapp::vec::VecMap;
 
 #[derive(Debug, Clone)]
@@ -84,6 +86,13 @@ impl CapabilityModel {
         return Self::Dynamic(RefCell::new(values.into()));
     }
 
+    pub fn iter(&mut self) -> std::slice::Iter<'_, Capability> {
+        match self {
+            CapabilityModel::Static(x) => x.iter(),
+            CapabilityModel::Dynamic(x) => x.get_mut().iter(),
+        }
+    }
+
     pub fn require(&self, capability: Capability) -> Result<()> {
         match self {
             CapabilityModel::Static(x) => {
@@ -109,7 +118,7 @@ impl CapabilityModel {
                 }
             }
             CapabilityModel::Dynamic(x) => {
-                let mut x = x.get_mut();
+                let x = x.get_mut();
                 if !x.contains(&capability) {
                     x.push(capability);
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use num_enum::TryFromPrimitive;
 use rspirv::spirv::{Capability, MemoryModel, StorageClass};
 use serde::{Deserialize, Serialize};
 use spirv::ExecutionModel;
-use std::ops::Deref;
+use std::{cell::RefCell, ops::Deref};
 use vector_mapp::vec::VecMap;
 
 #[derive(Debug, Clone)]
@@ -70,17 +70,21 @@ impl AddressingModel {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CapabilityModel {
     /// The compilation will fail if a required capability isn't manually enabled
     Static(#[serde(default)] Box<[Capability]>),
     /// The compiler may add new capabilities whenever required.
-    Dynamic(#[serde(default)] Vec<Capability>),
+    Dynamic(#[serde(default)] RefCell<Vec<Capability>>),
 }
 
 impl CapabilityModel {
-    pub fn require(&mut self, capability: Capability) -> Result<()> {
+    pub fn dynamic(values: impl Into<Vec<Capability>>) -> Self {
+        return Self::Dynamic(RefCell::new(values.into()));
+    }
+
+    pub fn require(&self, capability: Capability) -> Result<()> {
         match self {
             CapabilityModel::Static(x) => {
                 if !x.contains(&capability) {
@@ -88,6 +92,7 @@ impl CapabilityModel {
                 }
             }
             CapabilityModel::Dynamic(x) => {
+                let mut x = x.borrow_mut();
                 if !x.contains(&capability) {
                     x.push(capability);
                 }
@@ -95,16 +100,22 @@ impl CapabilityModel {
         }
         Ok(())
     }
-}
 
-impl Deref for CapabilityModel {
-    type Target = [Capability];
-
-    fn deref(&self) -> &Self::Target {
+    pub fn require_mut(&mut self, capability: Capability) -> Result<()> {
         match self {
-            CapabilityModel::Static(x) => x,
-            CapabilityModel::Dynamic(x) => x,
+            CapabilityModel::Static(x) => {
+                if !x.contains(&capability) {
+                    return Err(Error::msg(format!("Unable to enable {capability:?}")));
+                }
+            }
+            CapabilityModel::Dynamic(x) => {
+                let mut x = x.get_mut();
+                if !x.contains(&capability) {
+                    x.push(capability);
+                }
+            }
         }
+        Ok(())
     }
 }
 
@@ -115,19 +126,7 @@ impl IntoIterator for CapabilityModel {
     fn into_iter(self) -> Self::IntoIter {
         match self {
             CapabilityModel::Static(x) => x.into_vec().into_iter(),
-            CapabilityModel::Dynamic(x) => x.into_iter(),
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a CapabilityModel {
-    type Item = &'a Capability;
-    type IntoIter = std::slice::Iter<'a, Capability>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self {
-            CapabilityModel::Static(x) => x.iter(),
-            CapabilityModel::Dynamic(x) => x.iter(),
+            CapabilityModel::Dynamic(x) => x.into_inner().into_iter(),
         }
     }
 }
@@ -166,14 +165,14 @@ impl Config {
         capabilities
             .iter()
             .copied()
-            .try_for_each(|x| self.capabilities.require(x))
+            .try_for_each(|x| self.capabilities.require_mut(x))
     }
 }
 
 impl ConfigBuilder {
     /// Assert that capability is (or can be) enabled, enabling it if required (and possible).
     pub fn require_capability(&mut self, capability: Capability) -> Result<()> {
-        self.inner.capabilities.require(capability)
+        self.inner.capabilities.require_mut(capability)
     }
 
     pub fn set_addressing_model(&mut self, addressing_model: AddressingModel) -> Result<&mut Self> {
@@ -259,7 +258,7 @@ impl Into<wasmparser::WasmFeatures> for WasmFeatures {
 
 impl Default for CapabilityModel {
     fn default() -> Self {
-        Self::Dynamic(vec![Capability::Int64, Capability::Float64])
+        Self::dynamic(vec![Capability::Int64, Capability::Float64])
     }
 }
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -733,6 +733,50 @@ pub fn translate_logic<'a>(
             op1.neg()?.into()
         }
 
+        F32Ceil | F64Ceil => {
+            let ty = match op {
+                F32Ceil => ScalarType::F32,
+                F64Ceil => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.ceil()?.into()
+        }
+
+        F32Floor | F64Floor => {
+            let ty = match op {
+                F32Floor => ScalarType::F32,
+                F64Floor => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.floor()?.into()
+        }
+
+        F32Trunc | F64Trunc => {
+            let ty = match op {
+                F32Trunc => ScalarType::F32,
+                F64Trunc => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.trunc()?.into()
+        }
+
+        F32Nearest | F64Nearest => {
+            let ty = match op {
+                F32Nearest => ScalarType::F32,
+                F64Nearest => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.nearest()?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -156,7 +156,7 @@ pub fn translate_control_flow<'a>(
             function.anchors.push(Operation::Label(false_label))
         }
 
-        End => {
+        End | Return => {
             let value = match &block.end {
                 End::Return(Some(ty)) => Some(block.stack_pop(ty.clone(), module)?),
                 End::Return(None) => None,
@@ -178,9 +178,9 @@ pub fn translate_control_flow<'a>(
         }
 
         Select => {
+            let selector = block.stack_pop(ScalarType::Bool, module)?.into_bool()?;
             let false_operand = block.stack_pop_any()?;
             let true_operand = block.stack_pop_any()?;
-            let selector = block.stack_pop(ScalarType::Bool, module)?.into_bool()?;
 
             let value = match selector.get_constant_value()? {
                 Some(true) => true_operand,

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -711,6 +711,28 @@ pub fn translate_logic<'a>(
             op1.rotr(op2, module)?.into()
         }
 
+        F32Abs | F64Abs => {
+            let ty = match op {
+                F32Abs => ScalarType::F32,
+                F64Abs => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.abs()?.into()
+        }
+
+        F32Neg | F64Neg => {
+            let ty = match op {
+                F32Neg => ScalarType::F32,
+                F64Neg => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.neg()?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -18,7 +18,7 @@ use crate::{
     r#type::ScalarType,
 };
 use std::{cell::Cell, rc::Rc};
-use tracing::{debug, info};
+use tracing::debug;
 use wasmparser::{MemArg, Operator};
 use Operator::*;
 
@@ -318,11 +318,12 @@ pub fn translate_memory<'a>(
         }
 
         MemorySize { .. } => {
-            todo!()
+            let zero = Integer::new_constant_usize(0, module);
+            block.stack_push(zero)
         }
 
         MemoryGrow { .. } => match module.memory_grow_error {
-            MemoryGrowErrorKind::Hard => return Err(Error::msg("Spirv cannot allocate memory")),
+            MemoryGrowErrorKind::Hard => return Err(Error::msg("SPIR-V cannot allocate memory")),
             MemoryGrowErrorKind::Soft => block.stack_push(Integer::new_constant_isize(-1, module)),
         },
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -654,6 +654,39 @@ pub fn translate_logic<'a>(
             }
         }
 
+        I32Clz | I64Clz => {
+            let ty = match op {
+                I32Clz => ScalarType::I32,
+                I64Clz => ScalarType::I64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_integer()?;
+            op1.clz()?.into()
+        }
+
+        I32Ctz | I64Ctz => {
+            let ty = match op {
+                I32Ctz => ScalarType::I32,
+                I64Ctz => ScalarType::I64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_integer()?;
+            op1.ctz()?.into()
+        }
+
+        I32Popcnt | I64Popcnt => {
+            let ty = match op {
+                I32Popcnt => ScalarType::I32,
+                I64Popcnt => ScalarType::I64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op1 = block.stack_pop(ty, module)?.into_integer()?;
+            op1.popcnt()?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -777,6 +777,18 @@ pub fn translate_logic<'a>(
             op1.nearest()?.into()
         }
 
+        F32Min | F64Min => {
+            let ty: ScalarType = match op {
+                F32Min => ScalarType::F32,
+                F64Min => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.min(op2)?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -924,6 +924,108 @@ pub fn translate_comparison<'a>(
             .into()
         }
 
+        F32Le | F64Le => {
+            let ty = match op {
+                F32Le => ScalarType::F32,
+                F64Le => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatComparison {
+                kind: Comparison::Le,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
+        F32Lt | F64Lt => {
+            let ty = match op {
+                F32Lt => ScalarType::F32,
+                F64Lt => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatComparison {
+                kind: Comparison::Lt,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
+        F32Eq | F64Eq => {
+            let ty = match op {
+                F32Eq => ScalarType::F32,
+                F64Eq => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatEquality {
+                kind: Equality::Eq,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
+        F32Ne | F64Ne => {
+            let ty = match op {
+                F32Ne => ScalarType::F32,
+                F64Ne => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatEquality {
+                kind: Equality::Ne,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
+        F32Gt | F64Gt => {
+            let ty = match op {
+                F32Gt => ScalarType::F32,
+                F64Gt => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatComparison {
+                kind: Comparison::Gt,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
+        F32Ge | F64Ge => {
+            let ty = match op {
+                F32Ge => ScalarType::F32,
+                F64Ge => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            Bool::new(BoolSource::FloatComparison {
+                kind: Comparison::Ge,
+                op1,
+                op2,
+            })
+            .into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -687,6 +687,30 @@ pub fn translate_logic<'a>(
             op1.popcnt()?.into()
         }
 
+        I32Rotl | I64Rotl => {
+            let ty = match op {
+                I32Rotl => ScalarType::I32,
+                I64Rotl => ScalarType::I64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_integer()?;
+            let op1 = block.stack_pop(ty, module)?.into_integer()?;
+            op1.rotl(op2, module)?.into()
+        }
+
+        I32Rotr | I64Rotr => {
+            let ty = match op {
+                I32Rotr => ScalarType::I32,
+                I64Rotr => ScalarType::I64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_integer()?;
+            let op1 = block.stack_pop(ty, module)?.into_integer()?;
+            op1.rotr(op2, module)?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/block/mvp.rs
+++ b/src/fg/block/mvp.rs
@@ -789,6 +789,18 @@ pub fn translate_logic<'a>(
             op1.min(op2)?.into()
         }
 
+        F32Max | F64Max => {
+            let ty: ScalarType = match op {
+                F32Max => ScalarType::F32,
+                F64Max => ScalarType::F64,
+                _ => return Err(Error::unexpected()),
+            };
+
+            let op2 = block.stack_pop(ty, module)?.into_float()?;
+            let op1 = block.stack_pop(ty, module)?.into_float()?;
+            op1.max(op2)?.into()
+        }
+
         _ => return Ok(TranslationResult::NotFound),
     };
 

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -15,6 +15,10 @@ pub enum ExtendedSet {
 pub enum GLSLInstr {
     Sqrt = 31,
     Fabs = 4,
+    Ceil = 9,
+    Floor = 8,
+    Trunc = 3,
+    RoundEven = 2,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +31,11 @@ pub enum OpenCLInstr {
     // Left rotation
     Rotate = 161,
     Fabs = 23,
+    Ceil = 12,
+    Floor = 25,
+    Trunc = 66,
+    Rint = 53,
+    Copysign = 13,
 }
 
 impl Display for ExtendedSet {

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -19,6 +19,8 @@ pub enum GLSLInstr {
     Floor = 8,
     Trunc = 3,
     RoundEven = 2,
+    Fmin = 37,
+    Fmax = 40,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -36,6 +38,8 @@ pub enum OpenCLInstr {
     Trunc = 66,
     Rint = 53,
     Copysign = 13,
+    Fmin = 28,
+    Fmax = 27,
 }
 
 impl Display for ExtendedSet {

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -14,6 +14,7 @@ pub enum ExtendedSet {
 #[repr(u32)]
 pub enum GLSLInstr {
     Sqrt = 31,
+    Fabs = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +26,7 @@ pub enum OpenCLInstr {
     Popcount = 166,
     // Left rotation
     Rotate = 161,
+    Fabs = 23,
 }
 
 impl Display for ExtendedSet {

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -45,7 +45,7 @@ pub enum OpenCLInstr {
 impl Display for ExtendedSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExtendedSet::GLSL450 => write!(f, "GLSL450.std.450"),
+            ExtendedSet::GLSL450 => write!(f, "GLSL.std.450"),
             ExtendedSet::OpenCL => write!(f, "OpenCL.std"),
         }
     }

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -23,6 +23,8 @@ pub enum OpenCLInstr {
     Clz = 151,
     Ctz = 152,
     Popcount = 166,
+    // Left rotation
+    Rotate = 161,
 }
 
 impl Display for ExtendedSet {

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{cell::Cell, fmt::Display};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ExtendedInstrSet {
+pub enum ExtendedSet {
     // https://registry.khronos.org/SPIR-V/specs/unified1/GLSL.std.450.html
     GLSL450,
     // https://registry.khronos.org/SPIR-V/specs/unified1/OpenCL.ExtendedInstructionSet.100.html
@@ -25,11 +25,11 @@ pub enum OpenCLInstr {
     Popcount = 166,
 }
 
-impl Display for ExtendedInstrSet {
+impl Display for ExtendedSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExtendedInstrSet::GLSL450 => write!(f, "GLSL450.std.450"),
-            ExtendedInstrSet::OpenCL => write!(f, "OpenCL.std"),
+            ExtendedSet::GLSL450 => write!(f, "GLSL450.std.450"),
+            ExtendedSet::OpenCL => write!(f, "OpenCL.std"),
         }
     }
 }
@@ -37,7 +37,16 @@ impl Display for ExtendedInstrSet {
 #[derive(Debug)]
 pub struct ExtendedIs {
     pub(crate) translation: Cell<Option<spirv::Word>>,
-    pub kind: ExtendedInstrSet,
+    pub kind: ExtendedSet,
+}
+
+impl ExtendedIs {
+    pub fn new(kind: ExtendedSet) -> Self {
+        return Self {
+            translation: Cell::new(None),
+            kind,
+        };
+    }
 }
 
 impl Translation for &ExtendedIs {

--- a/src/fg/extended_is.rs
+++ b/src/fg/extended_is.rs
@@ -1,0 +1,58 @@
+use crate::translation::Translation;
+use serde::{Deserialize, Serialize};
+use std::{cell::Cell, fmt::Display};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExtendedInstrSet {
+    // https://registry.khronos.org/SPIR-V/specs/unified1/GLSL.std.450.html
+    GLSL450,
+    // https://registry.khronos.org/SPIR-V/specs/unified1/OpenCL.ExtendedInstructionSet.100.html
+    OpenCL,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum GLSLInstr {
+    Sqrt = 31,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum OpenCLInstr {
+    Sqrt = 61,
+    Clz = 151,
+    Ctz = 152,
+    Popcount = 166,
+}
+
+impl Display for ExtendedInstrSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtendedInstrSet::GLSL450 => write!(f, "GLSL450.std.450"),
+            ExtendedInstrSet::OpenCL => write!(f, "OpenCL.std"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ExtendedIs {
+    pub(crate) translation: Cell<Option<spirv::Word>>,
+    pub kind: ExtendedInstrSet,
+}
+
+impl Translation for &ExtendedIs {
+    fn translate(
+        self,
+        _: &super::module::ModuleBuilder,
+        _: Option<&super::function::FunctionBuilder>,
+        builder: &mut crate::translation::Builder,
+    ) -> crate::error::Result<rspirv::spirv::Word> {
+        if let Some(word) = self.translation.get() {
+            return Ok(word);
+        }
+
+        let word = builder.ext_inst_import(self.kind.to_string());
+        self.translation.set(Some(word));
+        return Ok(word);
+    }
+}

--- a/src/fg/function.rs
+++ b/src/fg/function.rs
@@ -6,14 +6,14 @@ use super::{
 };
 use crate::{
     config::{execution_model_capabilities, storage_class_capabilities, ConfigBuilder},
-    decorator::{self, VariableDecorator},
+    decorator::VariableDecorator,
     error::{Error, Result},
     r#type::Type,
     version::Version,
 };
 use once_cell::unsync::OnceCell;
 use rspirv::spirv::{Capability, ExecutionModel, StorageClass};
-use serde::{Deserialize, Serialize, __private::de};
+use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cell::Cell, collections::VecDeque, rc::Rc};
 use vector_mapp::vec::VecMap;
 use wasmparser::{Export, FuncType, FunctionBody, ValType};

--- a/src/fg/mod.rs
+++ b/src/fg/mod.rs
@@ -6,6 +6,7 @@ use crate::r#type::Type;
 use std::{cell::Cell, rc::Rc};
 
 pub mod block;
+pub mod extended_is;
 pub mod function;
 pub mod import;
 pub mod module;

--- a/src/fg/module.rs
+++ b/src/fg/module.rs
@@ -205,11 +205,7 @@ impl<'a> ModuleBuilder<'a> {
             )?;
             translate_constants(&op, &mut block)?;
 
-            let init_value = block
-                .stack
-                .pop_back()
-                .ok_or_else(|| Error::msg("Empty stack"))?;
-
+            let init_value = block.stack_pop_any()?;
             global_variables.push(match global.mutable {
                 true => match result.platform {
                     TargetPlatform::Vulkan { .. } => {

--- a/src/fg/module.rs
+++ b/src/fg/module.rs
@@ -1,5 +1,6 @@
 use super::{
     block::{mvp::translate_constants, translate_block, BlockBuilder, BlockReader},
+    extended_is::ExtendedIs,
     function::FunctionBuilder,
     import::{translate_spir_global, ImportResult},
     values::{integer::IntegerKind, pointer::Pointer, Value},
@@ -12,7 +13,7 @@ use crate::{
     version::{TargetPlatform, Version},
     Str,
 };
-use rspirv::spirv::{AddressingModel, Capability, MemoryModel, StorageClass};
+use rspirv::spirv::{AddressingModel, MemoryModel, StorageClass};
 use std::{borrow::Cow, cell::Cell, collections::VecDeque, rc::Rc};
 use tracing::warn;
 use wasmparser::{ExternalKind, FuncType, Payload, Validator};
@@ -56,6 +57,7 @@ impl CallableFunction {
 pub struct ModuleBuilder<'a> {
     pub platform: TargetPlatform,
     pub version: Version,
+    pub extended_is: Box<[Rc<ExtendedIs>]>,
     pub capabilities: CapabilityModel,
     pub extensions: Box<[Str<'static>]>,
     pub addressing_model: AddressingModel,
@@ -89,6 +91,10 @@ impl<'a> ModuleBuilder<'a> {
 
         let mut result = Self {
             platform: config.platform,
+            extended_is: config
+                .platform
+                .extended_is()
+                .map_or_else(Default::default, |x| Box::from([Rc::new(x)])),
             version: config.platform.into(),
             capabilities: config.capabilities,
             extensions: config.extensions,
@@ -257,24 +263,6 @@ impl<'a> ModuleBuilder<'a> {
 
         result.built_functions = built_functions.into_boxed_slice();
         return Ok(result);
-    }
-
-    /// Assert that capability is (or can be) enabled, enabling it if required (and possible).
-    pub fn require_capability(&mut self, capability: Capability) -> Result<()> {
-        return match self.capabilities {
-            CapabilityModel::Static(ref cap) if cap.contains(&capability) => Ok(()),
-            CapabilityModel::Dynamic(ref mut cap) => {
-                if !cap.contains(&capability) {
-                    cap.push(capability)
-                }
-                Ok(())
-            }
-            CapabilityModel::Static(_) => {
-                return Err(Error::msg(format!(
-                    "Capability '{capability:?}' is not enabled"
-                )))
-            }
-        };
     }
 
     pub fn isize_type(&self) -> ScalarType {

--- a/src/fg/values/bool.rs
+++ b/src/fg/values/bool.rs
@@ -6,7 +6,7 @@ use super::{
     pointer::Pointer,
 };
 use crate::error::Result;
-use std::{cell::Cell, ops::Deref, rc::Rc};
+use std::{cell::Cell, rc::Rc};
 
 #[derive(Debug, Clone)]
 pub struct Bool {
@@ -19,6 +19,11 @@ pub enum BoolSource {
     Constant(bool),
     FromInteger(Rc<Integer>),
     Negated(Rc<Bool>),
+    Select {
+        selector: Rc<Bool>,
+        true_value: Rc<Bool>,
+        false_value: Rc<Bool>,
+    },
     IntEquality {
         kind: Equality,
         op1: Rc<Integer>,

--- a/src/fg/values/float.rs
+++ b/src/fg/values/float.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::should_implement_trait)]
 
-use super::{integer::Integer, pointer::Pointer, vector::Vector, Value};
+use super::{bool::Bool, integer::Integer, pointer::Pointer, vector::Vector, Value};
 use crate::{
     error::{Error, Result},
     r#type::{ScalarType, Type},
@@ -33,6 +33,11 @@ pub enum FloatSource {
     Extracted {
         vector: Rc<Vector>,
         index: Rc<Integer>,
+    },
+    Select {
+        selector: Rc<Bool>,
+        true_value: Rc<Float>,
+        false_value: Rc<Float>,
     },
     FunctionCall {
         function_id: Rc<Cell<Option<rspirv::spirv::Word>>>,
@@ -105,6 +110,14 @@ impl Float {
                 Type::Scalar(ScalarType::F64) => FloatKind::Double,
                 _ => return Err(Error::unexpected()),
             },
+            FloatSource::Select {
+                true_value,
+                false_value,
+                ..
+            } => {
+                debug_assert_eq!(true_value.kind()?, false_value.kind()?);
+                return true_value.kind();
+            }
             FloatSource::Extracted { vector, .. } => match vector.element_type {
                 ScalarType::F32 => FloatKind::Single,
                 ScalarType::F64 => FloatKind::Double,

--- a/src/fg/values/float.rs
+++ b/src/fg/values/float.rs
@@ -65,6 +65,11 @@ pub enum ConstantSource {
 pub enum UnarySource {
     Abs,
     Neg,
+    Ceil,
+    Floor,
+    Trunc,
+    Nearest,
+    Sqrt,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,7 +78,6 @@ pub enum BinarySource {
     Sub,
     Mul,
     Div,
-    Sqrt,
 }
 
 #[derive(Debug, Clone)]
@@ -185,6 +189,75 @@ impl Float {
                 translation: Cell::new(None),
                 source: FloatSource::Unary {
                     source: UnarySource::Neg,
+                    op1: self,
+                },
+            },
+        });
+    }
+
+    pub fn ceil(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(f32::ceil(x)),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(f64::ceil(x)),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Ceil,
+                    op1: self,
+                },
+            },
+        });
+    }
+
+    pub fn floor(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(f32::floor(x)),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(f64::floor(x)),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Ceil,
+                    op1: self,
+                },
+            },
+        });
+    }
+
+    pub fn trunc(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(f32::trunc(x)),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(f64::trunc(x)),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Ceil,
+                    op1: self,
+                },
+            },
+        });
+    }
+
+    // Waiting for [`round_ties_even`](https://github.com/rust-lang/rust/issues/96710) to stabilize
+    pub fn nearest(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Nearest,
+                    op1: self,
+                },
+            },
+        });
+    }
+
+    pub fn sqrt(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(f32::sqrt(x)),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(f64::sqrt(x)),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Sqrt,
                     op1: self,
                 },
             },

--- a/src/fg/values/float.rs
+++ b/src/fg/values/float.rs
@@ -63,7 +63,8 @@ pub enum ConstantSource {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnarySource {
-    Negate,
+    Abs,
+    Neg,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,14 +163,32 @@ impl Float {
         }));
     }
 
-    pub fn negate(self: Rc<Self>) -> Self {
-        return Self {
-            translation: Cell::new(None),
-            source: FloatSource::Unary {
-                source: UnarySource::Negate,
-                op1: self,
+    pub fn abs(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(f32::abs(x)),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(f64::abs(x)),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Abs,
+                    op1: self,
+                },
             },
-        };
+        });
+    }
+
+    pub fn neg(self: Rc<Self>) -> Result<Self> {
+        return Ok(match self.get_constant_value()? {
+            Some(ConstantSource::Single(x)) => Float::new_constant_f32(-x),
+            Some(ConstantSource::Double(x)) => Float::new_constant_f64(-x),
+            _ => Self {
+                translation: Cell::new(None),
+                source: FloatSource::Unary {
+                    source: UnarySource::Neg,
+                    op1: self,
+                },
+            },
+        });
     }
 
     pub fn add(self: Rc<Self>, rhs: Rc<Float>) -> Result<Self> {

--- a/src/fg/values/integer.rs
+++ b/src/fg/values/integer.rs
@@ -40,6 +40,11 @@ pub enum IntegerSource {
         pointer: Rc<Pointer>,
         log2_alignment: Option<u32>,
     },
+    Select {
+        selector: Rc<Bool>,
+        true_value: Rc<Integer>,
+        false_value: Rc<Integer>,
+    },
     Extracted {
         vector: Rc<Vector>,
         index: Rc<Integer>,
@@ -148,6 +153,14 @@ impl Integer {
                 Type::Scalar(ScalarType::I64) => IntegerKind::Long,
                 _ => return Err(Error::unexpected()),
             },
+            IntegerSource::Select {
+                true_value,
+                false_value,
+                ..
+            } => {
+                debug_assert_eq!(true_value.kind(module)?, false_value.kind(module)?);
+                return true_value.kind(module);
+            }
             IntegerSource::Extracted { vector, .. } => match vector.element_type {
                 ScalarType::I32 => IntegerKind::Short,
                 ScalarType::I64 => IntegerKind::Long,

--- a/src/fg/values/integer.rs
+++ b/src/fg/values/integer.rs
@@ -75,6 +75,9 @@ pub enum ConstantSource {
 pub enum UnarySource {
     Not,
     Negate,
+    LeadingZeros,
+    TrainlingZeros,
+    BitCount,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -712,6 +715,72 @@ impl Integer {
                 source: BinarySource::UShr,
                 op1: self,
                 op2: rhs,
+            },
+        };
+
+        return Ok(Rc::new(Self {
+            translation: Cell::new(None),
+            source,
+        }));
+    }
+
+    pub fn clz(self: Rc<Self>) -> Result<Rc<Self>> {
+        let source = match self.get_constant_value()? {
+            Some(ConstantSource::Short(x)) => {
+                IntegerSource::Constant(ConstantSource::Short(u32::leading_zeros(x)))
+            }
+
+            Some(ConstantSource::Long(x)) => {
+                IntegerSource::Constant(ConstantSource::Long(u64::leading_zeros(x) as u64))
+            }
+
+            _ => IntegerSource::Unary {
+                source: UnarySource::LeadingZeros,
+                op1: self,
+            },
+        };
+
+        return Ok(Rc::new(Self {
+            translation: Cell::new(None),
+            source,
+        }));
+    }
+
+    pub fn ctz(self: Rc<Self>) -> Result<Rc<Self>> {
+        let source = match self.get_constant_value()? {
+            Some(ConstantSource::Short(x)) => {
+                IntegerSource::Constant(ConstantSource::Short(u32::trailing_zeros(x)))
+            }
+
+            Some(ConstantSource::Long(x)) => {
+                IntegerSource::Constant(ConstantSource::Long(u64::trailing_zeros(x) as u64))
+            }
+
+            _ => IntegerSource::Unary {
+                source: UnarySource::TrainlingZeros,
+                op1: self,
+            },
+        };
+
+        return Ok(Rc::new(Self {
+            translation: Cell::new(None),
+            source,
+        }));
+    }
+
+    pub fn popcnt(self: Rc<Self>) -> Result<Rc<Self>> {
+        let source = match self.get_constant_value()? {
+            Some(ConstantSource::Short(x)) => {
+                IntegerSource::Constant(ConstantSource::Short(u32::count_ones(x)))
+            }
+
+            Some(ConstantSource::Long(x)) => {
+                IntegerSource::Constant(ConstantSource::Long(u64::count_ones(x) as u64))
+            }
+
+            _ => IntegerSource::Unary {
+                source: UnarySource::BitCount,
+                op1: self,
             },
         };
 

--- a/src/fg/values/integer.rs
+++ b/src/fg/values/integer.rs
@@ -274,7 +274,9 @@ impl Integer {
         module: &mut ModuleBuilder,
     ) -> Result<Pointer> {
         match storage_class {
-            StorageClass::Generic => module.require_capability(Capability::GenericPointer)?,
+            StorageClass::Generic => module
+                .capabilities
+                .require_mut(Capability::GenericPointer)?,
             _ => {}
         }
 

--- a/src/fg/values/mod.rs
+++ b/src/fg/values/mod.rs
@@ -148,7 +148,7 @@ impl Value {
 
     pub fn to_pointer(
         self,
-        pointee: impl Into<ScalarType>,
+        pointee: impl Into<Type>,
         byte_offset: impl Into<Rc<Integer>>,
         module: &mut ModuleBuilder,
     ) -> Result<Rc<Pointer>> {

--- a/src/fg/values/pointer.rs
+++ b/src/fg/values/pointer.rs
@@ -31,10 +31,15 @@ pub struct Pointer {
 #[derive(Debug, Clone)]
 pub enum PointerSource {
     FunctionParam,
+    FromInteger(Rc<Integer>),
+    Select {
+        selector: Rc<Bool>,
+        true_value: Rc<Pointer>,
+        false_value: Rc<Pointer>,
+    },
     Casted {
         prev: Rc<Pointer>,
     },
-    FromInteger(Rc<Integer>),
     Loaded {
         pointer: Rc<Pointer>,
         log2_alignment: Option<u32>,

--- a/src/fg/values/pointer.rs
+++ b/src/fg/values/pointer.rs
@@ -413,19 +413,21 @@ impl Pointer {
 
     pub fn require_addressing(&self, module: &mut ModuleBuilder) -> Result<()> {
         match self.storage_class {
-            StorageClass::PhysicalStorageBuffer => {
-                module.require_capability(Capability::PhysicalStorageBufferAddresses)
-            }
-            _ => module.require_capability(Capability::Addresses),
+            StorageClass::PhysicalStorageBuffer => module
+                .capabilities
+                .require_mut(Capability::PhysicalStorageBufferAddresses),
+            _ => module.capabilities.require_mut(Capability::Addresses),
         }
     }
 
     pub fn require_variable_pointers(&self, module: &mut ModuleBuilder) -> Result<()> {
         match self.storage_class {
-            StorageClass::StorageBuffer | StorageClass::PhysicalStorageBuffer => {
-                module.require_capability(Capability::VariablePointersStorageBuffer)
-            }
-            _ => module.require_capability(Capability::VariablePointers),
+            StorageClass::StorageBuffer | StorageClass::PhysicalStorageBuffer => module
+                .capabilities
+                .require_mut(Capability::VariablePointersStorageBuffer),
+            _ => module
+                .capabilities
+                .require_mut(Capability::VariablePointers),
         }
     }
 }

--- a/src/fg/values/vector.rs
+++ b/src/fg/values/vector.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::should_implement_trait)]
 
 use super::{
+    bool::Bool,
     float::{Float, FloatSource},
     integer::{Integer, IntegerSource},
     pointer::Pointer,
@@ -22,6 +23,11 @@ pub enum VectorSource {
     Loaded {
         pointer: Rc<Pointer>,
         log2_alignment: Option<u32>,
+    },
+    Select {
+        selector: Rc<Bool>,
+        true_value: Rc<Vector>,
+        false_value: Rc<Vector>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::needless_return)]
 
 use config::Config;
-use docfg::docfg;
 use error::{Error, Result};
 use fg::module::ModuleBuilder;
 use once_cell::unsync::OnceCell;
@@ -16,7 +15,7 @@ use std::{
     ops::Deref,
 };
 
-#[cfg(all(feature = "spvc-validate", feature = "naga-validate"))]
+#[cfg(all(feature = "spvt-validate", feature = "naga-validate"))]
 compile_error!("You can't select both SPIRV-Tools and Naga validators. Only one can be enabled at the same time");
 #[cfg(all(feature = "spvc-glsl", feature = "naga-glsl"))]
 compile_error!("You can't select both SPIRV-Cross and Naga compilers for GLSL. Only one can be enabled at the same time");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,3 +206,31 @@ impl<'a> From<Str<'a>> for String {
         }
     }
 }
+
+pub(crate) fn wasm_min_f32(x: f32, y: f32) -> f32 {
+    if x.is_nan() || y.is_nan() {
+        return f32::NAN;
+    }
+    return f32::min(x, y);
+}
+
+pub(crate) fn wasm_min_f64(x: f64, y: f64) -> f64 {
+    if x.is_nan() || y.is_nan() {
+        return f64::NAN;
+    }
+    return f64::min(x, y);
+}
+
+pub(crate) fn wasm_max_f32(x: f32, y: f32) -> f32 {
+    if x.is_nan() || y.is_nan() {
+        return f32::NAN;
+    }
+    return f32::max(x, y);
+}
+
+pub(crate) fn wasm_max_f64(x: f64, y: f64) -> f64 {
+    if x.is_nan() || y.is_nan() {
+        return f64::NAN;
+    }
+    return f64::max(x, y);
+}

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -940,10 +940,152 @@ impl Translation for &Float {
                                 .translate(module, function, builder)?,
                             _ => return Err(Error::unexpected()),
                         };
-
                         let integer = builder.bitcast(integer_type, None, operand)?;
                         let masked = builder.bitwise_and(integer_type, None, integer, mask)?;
                         break 'brk builder.bitcast(result_type, None, masked);
+                    }
+                    FloatUnarySource::Ceil => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::GLSL450 => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        GLSLInstr::Ceil as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Ceil as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                            }
+                        }
+                        return Err(Error::msg(
+                            "Ceil rounding is not supported on this platform",
+                        ));
+                    }
+                    FloatUnarySource::Floor => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::GLSL450 => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        GLSLInstr::Floor as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Floor as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                            }
+                        }
+                        return Err(Error::msg(
+                            "Floor rounding is not supported on this platform",
+                        ));
+                    }
+                    FloatUnarySource::Trunc => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::GLSL450 => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        GLSLInstr::Trunc as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Trunc as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                            }
+                        }
+                        return Err(Error::msg(
+                            "Truncating rounding is not supported on this platform",
+                        ));
+                    }
+                    FloatUnarySource::Nearest => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::GLSL450 => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        GLSLInstr::RoundEven as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Rint as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                            }
+                        }
+                        return Err(Error::msg(
+                            "Rounding (ties to even) rounding is not supported on this platform",
+                        ));
+                    }
+                    FloatUnarySource::Sqrt => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::GLSL450 => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        GLSLInstr::Sqrt as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Sqrt as u32,
+                                        Some(Operand::IdRef(operand)),
+                                    );
+                                }
+                            }
+                        }
+                        return Err(Error::msg("Square root is not supported on this platform"));
                     }
                 }
             }
@@ -963,7 +1105,6 @@ impl Translation for &Float {
                     FloatBinarySource::Div => {
                         builder.f_div(result_type, None, operand_1, operand_2)
                     }
-                    FloatBinarySource::Sqrt => todo!(),
                 }
             }
         }?;

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1594,6 +1594,15 @@ impl Translation for &Operation {
                         (Some(false_label.clone()), Some(true_label.clone()))
                     }
 
+                    // True block ends up branching to the false label.
+                    (Some(Operation::Branch { label }), _) if label == false_label => {
+                        (Some(false_label.clone()), None)
+                    }
+
+                    (_, Some(Operation::Branch { label })) if label == true_label => {
+                        (Some(true_label.clone()), None)
+                    }
+
                     // False block ends up branching to the current label.
                     // False block is probably the continue target, leaving the true block as the "exit" branch
                     (_, Some(Operation::Branch { label })) if label == current_block => {

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -266,6 +266,8 @@ impl<'a> FunctionBuilder<'a> {
         }
 
         builder.end_function()?;
+        builder.select_block(None)?;
+
         return Ok(());
     }
 }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -126,7 +126,7 @@ impl Builder {
 }
 
 impl<'a> ModuleBuilder<'a> {
-    pub fn translate(self) -> Result<Builder> {
+    pub fn translate(mut self) -> Result<Builder> {
         let mut builder = Builder::new();
         builder.set_version(self.version.major, self.version.minor);
 
@@ -160,7 +160,7 @@ impl<'a> ModuleBuilder<'a> {
         }
 
         // Capabilities
-        for capability in &self.capabilities {
+        for capability in self.capabilities.iter() {
             builder.capability(*capability)
         }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -452,6 +452,17 @@ impl Translation for &Bool {
                 builder.i_not_equal(result_type, None, operand_1, zero)
             }
 
+            BoolSource::Select {
+                selector,
+                true_value,
+                false_value,
+            } => {
+                let object_1 = true_value.translate(module, function, builder)?;
+                let object_2 = false_value.translate(module, function, builder)?;
+                let condition = selector.translate(module, function, builder)?;
+                builder.select(result_type, None, condition, object_1, object_2)
+            }
+
             BoolSource::IntEquality { kind, op1, op2 } => {
                 let operand_1 = op1.translate(module, function, builder)?;
                 let operand_2 = op2.translate(module, function, builder)?;
@@ -595,6 +606,17 @@ impl Translation for &Integer {
                 Ok(builder.constant_u64(result_type, *x))
             }
 
+            IntegerSource::Select {
+                selector,
+                true_value,
+                false_value,
+            } => {
+                let object_1 = true_value.translate(module, function, builder)?;
+                let object_2 = false_value.translate(module, function, builder)?;
+                let condition = selector.translate(module, function, builder)?;
+                builder.select(result_type, None, condition, object_1, object_2)
+            }
+
             IntegerSource::Conversion(
                 IntConversionSource::FromLong(value)
                 | IntConversionSource::FromShort {
@@ -687,6 +709,7 @@ impl Translation for &Integer {
                 match source {
                     IntUnarySource::Not => builder.not(result_type, None, operand),
                     IntUnarySource::Negate => builder.s_negate(result_type, None, operand),
+                    IntUnarySource::BitCount => builder.bit_count(result_type, None, operand),
                 }
             }
 
@@ -757,6 +780,16 @@ impl Translation for &Float {
             ) => {
                 let float_value = value.translate(module, function, builder)?;
                 builder.f_convert(result_type, None, float_value)
+            }
+            FloatSource::Select {
+                selector,
+                true_value,
+                false_value,
+            } => {
+                let object_1 = true_value.translate(module, function, builder)?;
+                let object_2 = false_value.translate(module, function, builder)?;
+                let condition = selector.translate(module, function, builder)?;
+                builder.select(result_type, None, condition, object_1, object_2)
             }
             FloatSource::Loaded {
                 pointer,
@@ -857,6 +890,17 @@ impl Translation for &Rc<Pointer> {
             PointerSource::FromInteger(value) => {
                 let integer_value = value.translate(module, function, builder)?;
                 builder.convert_u_to_ptr(pointer_type, None, integer_value)
+            }
+
+            PointerSource::Select {
+                selector,
+                true_value,
+                false_value,
+            } => {
+                let object_1 = true_value.translate(module, function, builder)?;
+                let object_2 = false_value.translate(module, function, builder)?;
+                let condition = selector.translate(module, function, builder)?;
+                builder.select(pointer_type, None, condition, object_1, object_2)
             }
 
             PointerSource::Loaded {
@@ -1017,6 +1061,16 @@ impl Translation for &Vector {
                 };
                 let (memory_access, additional_params) = additional_access_info(*log2_alignment);
                 builder.load(result_type, None, pointer, memory_access, additional_params)
+            }
+            VectorSource::Select {
+                selector,
+                true_value,
+                false_value,
+            } => {
+                let object_1 = true_value.translate(module, function, builder)?;
+                let object_2 = false_value.translate(module, function, builder)?;
+                let condition = selector.translate(module, function, builder)?;
+                builder.select(result_type, None, condition, object_1, object_2)
             }
         }?;
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -32,7 +32,7 @@ use rspirv::{
         MemoryAccess, Op, SelectionControl,
     },
 };
-use spirv::Capability;
+use spirv::{Capability, StorageClass};
 use std::{
     cmp::Ordering,
     collections::HashMap,
@@ -828,7 +828,8 @@ impl Translation for &Float {
             return Ok(res);
         }
 
-        let result_bits = match self.kind()? {
+        let kind = self.kind()?;
+        let result_bits = match kind {
             FloatKind::Single => 32,
             FloatKind::Double => 64,
         };
@@ -1130,9 +1131,19 @@ impl Translation for &Float {
                         const F64_NAN_ODDS: u64 = (1u64 << f64::MANTISSA_DIGITS) - 2;
                         const F64_OTHER_ODDS: u64 = u64::MAX - F64_NAN_ODDS;
 
-                        let (nan_odds, other_odds) = match result_bits {
-                            32 => (F32_NAN_ODDS, F32_OTHER_ODDS),
-                            64 => ((F64_NAN_ODDS >> 32) as u32, (F64_OTHER_ODDS >> 32) as u32),
+                        let (nan, nan_odds, other_odds) = match result_bits {
+                            32 => (
+                                Float::new_constant_f32(f32::NAN)
+                                    .translate(module, function, builder)?,
+                                F32_NAN_ODDS,
+                                F32_OTHER_ODDS,
+                            ),
+                            64 => (
+                                Float::new_constant_f64(f64::NAN)
+                                    .translate(module, function, builder)?,
+                                (F64_NAN_ODDS >> 32) as u32,
+                                (F64_OTHER_ODDS >> 32) as u32,
+                            ),
                             _ => return Err(Error::unexpected()),
                         };
 
@@ -1146,7 +1157,7 @@ impl Translation for &Float {
                         let merge_label = builder.id();
 
                         let current_block = builder.selected_block();
-                        builder.selection_merge(merge_label, SelectionControl::FLATTEN);
+                        builder.selection_merge(merge_label, SelectionControl::FLATTEN)?;
                         builder.select_block(current_block)?;
                         builder.branch_conditional(
                             is_nan,
@@ -1155,16 +1166,100 @@ impl Translation for &Float {
                             [nan_odds, other_odds],
                         )?;
 
-                        builder.begin_block(Some(true_label));
-                        let nan = match result_bits {
-                            32 => Float::new_constant_f32(f32::NAN),
-                            64 => Float::new_constant_f64(f64::NAN),
-                            _ => return Err(Error::unexpected()),
-                        }
+                        let result = Rc::new(Pointer::new_variable(
+                            StorageClass::Function,
+                            kind,
+                            Vec::new(),
+                        ))
                         .translate(module, function, builder)?;
-                        builder.begin_block(Some(true_label));
-                        builder.begin_block(Some(merge_label));
-                        todo!()
+
+                        builder.begin_block(Some(true_label))?;
+                        builder.store(result, nan, None, None)?;
+                        builder.branch(merge_label)?;
+
+                        builder.begin_block(Some(false_label))?;
+                        let fast_min = fast_fmin(
+                            boolean,
+                            result_type,
+                            module,
+                            function,
+                            builder,
+                            operand_1,
+                            operand_2,
+                        )?;
+                        builder.store(result, fast_min, None, None)?;
+                        builder.branch(merge_label)?;
+
+                        builder.begin_block(Some(merge_label))?;
+                        Ok(result)
+                    }
+                    FloatBinarySource::Max => {
+                        const F32_NAN_ODDS: u32 = (1u32 << f32::MANTISSA_DIGITS) - 2;
+                        const F32_OTHER_ODDS: u32 = u32::MAX - F32_NAN_ODDS;
+                        const F64_NAN_ODDS: u64 = (1u64 << f64::MANTISSA_DIGITS) - 2;
+                        const F64_OTHER_ODDS: u64 = u64::MAX - F64_NAN_ODDS;
+
+                        let (nan, nan_odds, other_odds) = match result_bits {
+                            32 => (
+                                Float::new_constant_f32(f32::NAN)
+                                    .translate(module, function, builder)?,
+                                F32_NAN_ODDS,
+                                F32_OTHER_ODDS,
+                            ),
+                            64 => (
+                                Float::new_constant_f64(f64::NAN)
+                                    .translate(module, function, builder)?,
+                                (F64_NAN_ODDS >> 32) as u32,
+                                (F64_OTHER_ODDS >> 32) as u32,
+                            ),
+                            _ => return Err(Error::unexpected()),
+                        };
+
+                        let boolean = builder.type_bool();
+                        let is_nan_1 = builder.is_nan(boolean, None, operand_1)?;
+                        let is_nan_2 = builder.is_nan(boolean, None, operand_2)?;
+                        let is_nan = builder.logical_or(boolean, None, is_nan_1, is_nan_2)?;
+
+                        let true_label = builder.id();
+                        let false_label = builder.id();
+                        let merge_label = builder.id();
+
+                        let current_block = builder.selected_block();
+                        builder.selection_merge(merge_label, SelectionControl::FLATTEN)?;
+                        builder.select_block(current_block)?;
+                        builder.branch_conditional(
+                            is_nan,
+                            true_label,
+                            false_label,
+                            [nan_odds, other_odds],
+                        )?;
+
+                        let result = Rc::new(Pointer::new_variable(
+                            StorageClass::Function,
+                            kind,
+                            Vec::new(),
+                        ))
+                        .translate(module, function, builder)?;
+
+                        builder.begin_block(Some(true_label))?;
+                        builder.store(result, nan, None, None)?;
+                        builder.branch(merge_label)?;
+
+                        builder.begin_block(Some(false_label))?;
+                        let fast_max = fast_fmax(
+                            boolean,
+                            result_type,
+                            module,
+                            function,
+                            builder,
+                            operand_1,
+                            operand_2,
+                        )?;
+                        builder.store(result, fast_max, None, None)?;
+                        builder.branch(merge_label)?;
+
+                        builder.begin_block(Some(merge_label))?;
+                        Ok(result)
                     }
                 }
             }
@@ -1698,15 +1793,82 @@ fn additional_access_info(log2_alignment: Option<u32>) -> (Option<MemoryAccess>,
         .unzip()
 }
 
-fn fast_min(module: &ModuleBuilder, builder: &mut Builder, operand_1: spirv::Word, operand_2: spirv::Word) -> spirv::Word {
+fn fast_fmin(
+    boolean: spirv::Word,
+    result_type: spirv::Word,
+    module: &ModuleBuilder,
+    function: Option<&FunctionBuilder>,
+    builder: &mut Builder,
+    operand_1: spirv::Word,
+    operand_2: spirv::Word,
+) -> Result<spirv::Word> {
     for is in module.extended_is.iter() {
         match is.kind {
-            ExtendedSet::OpenCL => {
-                let extended_set = builder.
+            ExtendedSet::GLSL450 => {
+                let extension_set = is.translate(module, function, builder)?;
+                return Ok(builder.ext_inst(
+                    result_type,
+                    None,
+                    extension_set,
+                    GLSLInstr::Fmin as u32,
+                    [Operand::IdRef(operand_1), Operand::IdRef(operand_2)],
+                )?);
             }
-            _ => continue,
+            ExtendedSet::OpenCL => {
+                let extension_set = is.translate(module, function, builder)?;
+                return Ok(builder.ext_inst(
+                    result_type,
+                    None,
+                    extension_set,
+                    OpenCLInstr::Fmin as u32,
+                    [Operand::IdRef(operand_1), Operand::IdRef(operand_2)],
+                )?);
+            }
         }
     }
 
-    todo!()
+    let condition = builder.f_unord_less_than_equal(boolean, None, operand_1, operand_2)?;
+    builder
+        .select(result_type, None, condition, operand_1, operand_2)
+        .map_err(Into::into)
+}
+
+fn fast_fmax(
+    boolean: spirv::Word,
+    result_type: spirv::Word,
+    module: &ModuleBuilder,
+    function: Option<&FunctionBuilder>,
+    builder: &mut Builder,
+    operand_1: spirv::Word,
+    operand_2: spirv::Word,
+) -> Result<spirv::Word> {
+    for is in module.extended_is.iter() {
+        match is.kind {
+            ExtendedSet::GLSL450 => {
+                let extension_set = is.translate(module, function, builder)?;
+                return Ok(builder.ext_inst(
+                    result_type,
+                    None,
+                    extension_set,
+                    GLSLInstr::Fmax as u32,
+                    [Operand::IdRef(operand_1), Operand::IdRef(operand_2)],
+                )?);
+            }
+            ExtendedSet::OpenCL => {
+                let extension_set = is.translate(module, function, builder)?;
+                return Ok(builder.ext_inst(
+                    result_type,
+                    None,
+                    extension_set,
+                    OpenCLInstr::Fmax as u32,
+                    [Operand::IdRef(operand_1), Operand::IdRef(operand_2)],
+                )?);
+            }
+        }
+    }
+
+    let condition = builder.f_unord_greater_than_equal(boolean, None, operand_1, operand_2)?;
+    builder
+        .select(result_type, None, condition, operand_1, operand_2)
+        .map_err(Into::into)
 }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1158,6 +1158,13 @@ impl Translation for &Float {
                         let false_label = builder.id();
                         let merge_label = builder.id();
 
+                        let result = Rc::new(Pointer::new_variable(
+                            StorageClass::Function,
+                            kind,
+                            Vec::new(),
+                        ))
+                        .translate(module, function, builder)?;
+
                         let current_block = builder.selected_block();
                         builder.selection_merge(merge_label, SelectionControl::FLATTEN)?;
                         builder.select_block(current_block)?;
@@ -1167,13 +1174,6 @@ impl Translation for &Float {
                             false_label,
                             [nan_odds, other_odds],
                         )?;
-
-                        let result = Rc::new(Pointer::new_variable(
-                            StorageClass::Function,
-                            kind,
-                            Vec::new(),
-                        ))
-                        .translate(module, function, builder)?;
 
                         builder.begin_block(Some(true_label))?;
                         builder.store(result, nan, None, None)?;

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -787,6 +787,27 @@ impl Translation for &Integer {
                     IntBinarySource::UShr => {
                         builder.shift_right_logical(result_type, None, operand_1, operand_2)
                     }
+                    IntBinarySource::Rotl => 'brk: {
+                        for is in module.extended_is.iter() {
+                            match is.kind {
+                                ExtendedSet::OpenCL => {
+                                    let extension_set = is.translate(module, function, builder)?;
+                                    break 'brk builder.ext_inst(
+                                        result_type,
+                                        None,
+                                        extension_set,
+                                        OpenCLInstr::Rotate as u32,
+                                        [Operand::IdRef(operand_1), Operand::IdRef(operand_2)],
+                                    );
+                                }
+                                _ => continue,
+                            }
+                        }
+                        todo!()
+                    }
+                    IntBinarySource::Rotr => 'brk: {
+                        todo!()
+                    }
                 }
             }
         }?;

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{Error, Result},
     fg::{
-        function::{self, ExecutionMode, FunctionBuilder, Schrodinger, Storeable},
+        function::{ExecutionMode, FunctionBuilder, Schrodinger, Storeable},
         module::{GlobalVariable, ModuleBuilder},
         values::{
             bool::{Bool, BoolSource, Comparison, Equality},
@@ -19,7 +19,7 @@ use crate::{
             vector::{Vector, VectorSource},
             Value,
         },
-        End, Label, Operation,
+        Label, Operation,
     },
     r#type::{CompositeType, ScalarType, Type},
     version::Version,
@@ -37,7 +37,6 @@ use std::{
     ops::{Deref, DerefMut},
     rc::Rc,
 };
-use tracing::{debug, info};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Constant {
@@ -285,7 +284,7 @@ impl Translation for ScalarType {
     fn translate(
         self,
         _: &ModuleBuilder,
-        function: Option<&FunctionBuilder>,
+        _: Option<&FunctionBuilder>,
         builder: &mut Builder,
     ) -> Result<rspirv::spirv::Word> {
         return Ok(match self {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,7 @@
-use crate::{error::Error, fg::extended_is::ExtendedInstrSet};
+use crate::{
+    error::Error,
+    fg::extended_is::{ExtendedIs, ExtendedSet},
+};
 use docfg::docfg;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
@@ -91,9 +94,10 @@ impl TargetPlatform {
 
     pub fn extended_is(&self) -> Option<ExtendedIs> {
         let kind = match self {
+            Self::Vulkan(_) => ExtendedSet::GLSL450,
             _ => return None,
         };
-        todo!()
+        return Some(ExtendedIs::new(kind));
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::{error::Error, fg::extended_is::ExtendedInstrSet};
 use docfg::docfg;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
@@ -88,6 +88,13 @@ impl TargetPlatform {
     pub const VK_1_0: TargetPlatform = Self::Vulkan(Version::V1_0);
     pub const VK_1_1: TargetPlatform = Self::Vulkan(Version::V1_1);
     pub const VK_1_2: TargetPlatform = Self::Vulkan(Version::V1_2);
+
+    pub fn extended_is(&self) -> Option<ExtendedIs> {
+        let kind = match self {
+            _ => return None,
+        };
+        todo!()
+    }
 }
 
 #[docfg(feature = "spirv-tools")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -92,7 +92,7 @@ fn test() -> color_eyre::Result<()> {
     //let wat = include_str!("saxpy.wat");
     //let wasm = wat::parse_str(include_str!("../examples/saxpy.wat"))?;
 
-    let wasm = wat::parse_bytes(include_bytes!("../examples/saxpy/saxpy.wat"))?;
+    let wasm = wat::parse_bytes(include_bytes!("../examples/out/min.wasm"))?;
     let module = ModuleBuilder::new(config, &wasm)?;
     let spirv = module.translate().unwrap();
 


### PR DESCRIPTION
Added support for this integer instructions:
- Popcnt
- Clz (Count leading zeros)
- Ctz (Count trailing zeros)

Added support for this float instructions:
- Abs (Absolute value)
- Ceil
- Truncate
- Floor
- Nearest
- Sqrt (Square root)
- Copysign
- Min
- Max

And partial support for this instructions:
- Rotl (Rotate left)
    - Only works with OpenCL extended is, panics otherwise
- Rotr (Rotate right)
   - Only parsing works, translation panics 