### PR TITLE
Disable syntax highligh features/dependencies from WebAssembly CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,17 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            features: khronos-all naga-wgsl
+            features: tree-sitter khronos-all naga-wgsl
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            features: khronos-all naga-wgsl
+            features: tree-sitter khronos-all naga-wgsl
             ext: .exe
           - target: aarch64-apple-darwin
             os: macos-latest
-            features: khronos-all naga-wgsl
+            features: tree-sitter khronos-all naga-wgsl
           - target: x86_64-apple-darwin
             os: macos-latest
-            features: khronos-all naga-wgsl
+            features: tree-sitter khronos-all naga-wgsl
           - target: wasm32-wasi
             os: ubuntu-latest
             features: naga-all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Macro features
-cli = ["clap", "color-eyre", "serde_json", "tree-sitter", "colored"]
+cli = ["clap", "color-eyre", "serde_json"]
 khronos-all = ["spvt-validate", "spvc-glsl", "spvc-hlsl", "spvc-msl"]
 naga-all = ["naga-validate", "naga-glsl", "naga-hlsl", "naga-msl", "naga-wgsl"]
-tree-sitter = ["dep:tree-sitter", "tree-sitter-highlight", "tree-sitter-asm"]
+tree-sitter = [
+    "dep:tree-sitter",
+    "tree-sitter-highlight",
+    "tree-sitter-asm",
+    "colored",
+]
 # SPIR-V Cross compilers
 spvc-glsl = ["spirv_cross", "spirv_cross/glsl", "tree-sitter-glsl"]
 spvc-hlsl = ["spirv_cross", "spirv_cross/hlsl", "tree-sitter-hlsl"]
@@ -48,13 +53,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "wasm2spirv"
 path = "src/cli.rs"
-required-features = [
-    "clap",
-    "color-eyre",
-    "serde_json",
-    "tree-sitter",
-    "colored",
-]
+required-features = ["clap", "color-eyre", "serde_json"]
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -74,6 +73,11 @@ spirv_cross = { version = "0.23.1", optional = true }
 thiserror = "1.0.43"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
+vector_mapp = { version = "0.3.2", features = ["serde"] }
+wasmparser = "0.109.0"
+wat = "1.0.67"
+
+[target.'cfg(any(unix, windows))'.dependencies]
 tree-sitter = { version = "0.20.10", optional = true }
 tree-sitter-asm = { version = "0.1.0", optional = true }
 tree-sitter-c = { version = "0.20.4", optional = true }
@@ -81,9 +85,6 @@ tree-sitter-glsl = { version = "0.1.4", optional = true }
 tree-sitter-highlight = { version = "0.20.1", optional = true }
 tree-sitter-hlsl = { version = "0.1.2", optional = true }
 tree-sitter-wgsl = { version = "0.0.6", optional = true }
-vector_mapp = { version = "0.3.2", features = ["serde"] }
-wasmparser = "0.109.0"
-wat = "1.0.67"
 
 [dev-dependencies]
 color-eyre = "0.6.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,7 @@ struct Cli {
     /// When printing to the standard output, syntax highlights will be added.
     /// (Currently, it only works for assembly and GLSL outputs)
     #[arg(long)]
+    #[cfg(feature = "tree-sitter")]
     highlight: bool,
 
     /// Optimizes the compiled result
@@ -80,6 +81,7 @@ pub fn main() -> color_eyre::Result<()> {
         from_json,
         output,
         quiet,
+        #[cfg(feature = "tree-sitter")]
         highlight,
         #[cfg(feature = "spirv-tools")]
         optimize,


### PR DESCRIPTION
Since tree-sitter doesn't compile on WebAssembly, it must not be enabled on that platfotm.